### PR TITLE
Add basic unit test coverage for proxy implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.sonatype.nexus</groupId>
             <artifactId>nexus-rapture</artifactId>
             <scope>provided</scope>

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/AssetKindTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/AssetKindTest.java
@@ -1,0 +1,38 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.sonatype.nexus.repository.cache.CacheControllerHolder.CONTENT;
+import static org.sonatype.nexus.repository.cache.CacheControllerHolder.METADATA;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.LIST;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.PACKAGES;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.PROVIDER;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.ZIPBALL;
+
+public class AssetKindTest
+    extends TestSupport
+{
+  @Test
+  public void cacheTypes() {
+    assertThat(LIST.getCacheType(), is(METADATA));
+    assertThat(PROVIDER.getCacheType(), is(METADATA));
+    assertThat(PACKAGES.getCacheType(), is(METADATA));
+    assertThat(ZIPBALL.getCacheType(), is(CONTENT));
+  }
+}

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImplTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImplTest.java
@@ -1,0 +1,282 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import java.io.InputStream;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.blobstore.api.Blob;
+import org.sonatype.nexus.blobstore.api.BlobRef;
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
+import org.sonatype.nexus.common.hash.HashAlgorithm;
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.AssetBlob;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.Query;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.storage.TempBlob;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+import com.google.common.hash.HashCode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.sonatype.nexus.common.hash.HashAlgorithm.MD5;
+import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA1;
+import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA256;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.LIST;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.PACKAGES;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.PROVIDER;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.ZIPBALL;
+import static org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter.P_NAME;
+
+public class ComposerContentFacetImplTest
+    extends TestSupport
+{
+  private static final String CONTENT_TYPE = "content-type";
+
+  private static final Format COMPOSER_FORMAT = new ComposerFormat();
+
+  private static final Date LAST_MODIFIED = new Date();
+
+  private static final Date LAST_VERIFIED = new Date();
+
+  private static final String ETAG = "etag";
+
+  private static final List<HashAlgorithm> HASH_ALGORITHMS = asList(MD5, SHA1, SHA256);
+
+  private static final Map<HashAlgorithm, HashCode> CHECKSUMS = singletonMap(SHA256, HashCode.fromInt(1));
+
+  private static final String LIST_PATH = "packages/list.json";
+
+  private static final String PACKAGES_PATH = "packages.json";
+
+  private static final String PROVIDER_PATH = "p/vendor/project.json";
+
+  private static final String ZIPBALL_PATH = "vendor/project/version/project-version.zip";
+
+  @Mock
+  private Component component;
+
+  @Mock
+  private Asset asset;
+
+  @Mock
+  private BlobRef blobRef;
+
+  @Mock
+  private Blob blob;
+
+  @Mock
+  private InputStream blobInputStream;
+
+  @Mock
+  private Repository repository;
+
+  @Mock
+  private StorageFacet storageFacet;
+
+  @Mock
+  private Bucket bucket;
+
+  @Mock
+  private StorageTx tx;
+
+  @Mock
+  private Content upload;
+
+  @Mock
+  private NestedAttributesMap assetAttributes;
+
+  @Mock
+  private NestedAttributesMap contentAttributes;
+
+  @Mock
+  private NestedAttributesMap cacheAttributes;
+
+  @Mock
+  private NestedAttributesMap formatAttributes;
+
+  @Mock
+  private AssetBlob assetBlob;
+
+  @Mock
+  private TempBlob tempBlob;
+
+  private ComposerContentFacetImpl underTest;
+
+  @Before
+  public void setUp() throws Exception {
+    underTest = new ComposerContentFacetImpl(COMPOSER_FORMAT);
+    underTest.attach(repository);
+
+    when(tx.findBucket(repository)).thenReturn(bucket);
+    when(tx.requireBlob(blobRef)).thenReturn(blob);
+    when(tx.createAsset(bucket, COMPOSER_FORMAT)).thenReturn(asset);
+    when(tx.createAsset(bucket, component)).thenReturn(asset);
+    when(tx.findComponents(any(Query.class), eq(singletonList(repository)))).thenReturn(emptyList());
+    when(tx.createComponent(bucket, COMPOSER_FORMAT)).thenReturn(component);
+
+    when(repository.facet(StorageFacet.class)).thenReturn(storageFacet);
+
+    when(asset.attributes()).thenReturn(assetAttributes);
+    when(asset.formatAttributes()).thenReturn(formatAttributes);
+    when(asset.requireBlobRef()).thenReturn(blobRef);
+    when(asset.requireContentType()).thenReturn(CONTENT_TYPE);
+    when(asset.getChecksums(HASH_ALGORITHMS)).thenReturn(CHECKSUMS);
+
+    when(assetAttributes.child("cache")).thenReturn(cacheAttributes);
+    when(assetAttributes.child("composer")).thenReturn(formatAttributes);
+    when(assetAttributes.child("content")).thenReturn(contentAttributes);
+
+    when(assetBlob.getBlob()).thenReturn(blob);
+    when(assetBlob.getBlobRef()).thenReturn(blobRef);
+
+    when(contentAttributes.get("last_modified", Date.class)).thenReturn(LAST_MODIFIED);
+    when(contentAttributes.get("etag")).thenReturn(ETAG);
+
+    when(cacheAttributes.get("last_verified", Date.class)).thenReturn(LAST_VERIFIED);
+
+    when(storageFacet.createTempBlob(upload, HASH_ALGORITHMS)).thenReturn(tempBlob);
+
+    when(blob.getInputStream()).thenReturn(blobInputStream);
+
+    when(upload.getContentType()).thenReturn(CONTENT_TYPE);
+
+    when(component.group(any(String.class))).thenReturn(component);
+    when(component.name(any(String.class))).thenReturn(component);
+    when(component.version(any(String.class))).thenReturn(component);
+
+    UnitOfWork.beginBatch(tx);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    UnitOfWork.end();
+  }
+
+  @Test
+  public void getAssetNotFound() throws Exception {
+    assertThat(underTest.get("path"), is(nullValue()));
+  }
+
+  @Test
+  public void getAssetFoundWithoutUpdate() throws Exception {
+    testGet(ZIPBALL_PATH, false);
+  }
+
+  @Test
+  public void getAssetFoundWithUpdate() throws Exception {
+    testGet(ZIPBALL_PATH, true);
+  }
+
+  @Test
+  public void putListJson() throws Exception {
+    testPutOrUpdate(LIST, LIST_PATH, false);
+  }
+
+  @Test
+  public void putPackagesJson() throws Exception {
+    testPutOrUpdate(PACKAGES, PACKAGES_PATH, false);
+  }
+
+  @Test
+  public void putProviderJson() throws Exception {
+    testPutOrUpdate(PROVIDER, PROVIDER_PATH, false);
+  }
+
+  @Test
+  public void putZipball() throws Exception {
+    testPutOrUpdate(ZIPBALL, ZIPBALL_PATH, false);
+  }
+
+  @Test
+  public void updateListJson() throws Exception {
+    testPutOrUpdate(LIST, LIST_PATH, true);
+  }
+
+  @Test
+  public void updatePackagesJson() throws Exception {
+    testPutOrUpdate(PACKAGES, PACKAGES_PATH, true);
+  }
+
+  @Test
+  public void updateProviderJson() throws Exception {
+    testPutOrUpdate(PROVIDER, PROVIDER_PATH, true);
+  }
+
+  @Test
+  public void updateZipball() throws Exception {
+    testPutOrUpdate(ZIPBALL, ZIPBALL_PATH, true);
+  }
+
+  private void testGet(final String path, final boolean markAsDownloaded) throws Exception {
+    when(tx.findAssetWithProperty(P_NAME, path, bucket)).thenReturn(asset);
+    when(asset.markAsDownloaded()).thenReturn(markAsDownloaded);
+
+    Content content = underTest.get(path);
+    assertThat(content, is(notNullValue()));
+    assertThat(content.openInputStream(), is(blobInputStream));
+    assertThat(content.getContentType(), is(CONTENT_TYPE));
+
+    if (markAsDownloaded) {
+      verify(tx).saveAsset(asset);
+    }
+    else {
+      verify(tx, never()).saveAsset(asset);
+    }
+  }
+
+  private void testPutOrUpdate(final AssetKind assetKind, final String path, final boolean update) throws Exception {
+    when(tx.setBlob(asset, path, tempBlob, null, CONTENT_TYPE, false)).thenReturn(assetBlob);
+    if (update) {
+      when(tx.findComponents(any(Query.class), eq(singletonList(repository)))).thenReturn(singletonList(component));
+      when(tx.findAssetWithProperty(P_NAME, path, bucket)).thenReturn(asset);
+    }
+
+    Content content = underTest.put(path, upload, assetKind);
+    assertThat(content, is(notNullValue()));
+    assertThat(content.openInputStream(), is(blobInputStream));
+    assertThat(content.getContentType(), is(CONTENT_TYPE));
+
+    verify(tx).saveAsset(asset);
+    if (!update && ZIPBALL.equals(assetKind)) {
+      verify(component).group("vendor");
+      verify(component).name("project");
+      verify(component).version("version");
+    }
+  }
+}

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.Payload;
+
+import com.google.common.io.CharStreams;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class ComposerJsonProcessorTest
+    extends TestSupport
+{
+  @Mock
+  private Repository repository;
+
+  @Mock
+  private Payload payload;
+
+  @Test
+  public void generatePackagesFromList() throws Exception {
+    String listJson = readStreamToString(getClass().getResourceAsStream("generatePackagesFromList.list.json"));
+    String packagesJson = readStreamToString(getClass().getResourceAsStream("generatePackagesFromList.packages.json"));
+
+    when(repository.getUrl()).thenReturn("http://nexus.repo/base/repo");
+    when(payload.openInputStream()).thenReturn(new ByteArrayInputStream(listJson.getBytes(UTF_8)));
+
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor();
+    Content output = underTest.generatePackagesJson(repository, payload);
+
+    assertEquals(readStreamToString(output.openInputStream()), packagesJson, false);
+  }
+
+  @Test
+  public void rewriteProviderJson() throws Exception {
+    String inputJson = readStreamToString(getClass().getResourceAsStream("rewriteProviderJson.input.json"));
+    String outputJson = readStreamToString(getClass().getResourceAsStream("rewriteProviderJson.output.json"));
+
+    when(repository.getUrl()).thenReturn("http://nexus.repo/base/repo");
+    when(payload.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson.getBytes(UTF_8)));
+
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor();
+    Payload output = underTest.rewriteProviderJson(repository, payload);
+
+    assertEquals(readStreamToString(output.openInputStream()), outputJson, false);
+  }
+
+  @Test
+  public void getDistUrl() throws Exception {
+    String inputJson = readStreamToString(getClass().getResourceAsStream("getDistUrl.json"));
+    when(payload.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson.getBytes(UTF_8)));
+
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor();
+    String distUrl = underTest.getDistUrl("vendor1", "project1", "2.0.0", payload);
+
+    assertThat(distUrl, is("https://git.example.com/zipball/418e708b379598333d0a48954c0fa210437795be"));
+  }
+
+  private String readStreamToString(final InputStream in) throws IOException {
+    try {
+      return CharStreams.toString(new InputStreamReader(in, UTF_8));
+    }
+    finally {
+      in.close();
+    }
+  }
+}

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerProviderHandlerTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerProviderHandlerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.common.collect.AttributesMap;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Payload;
+import org.sonatype.nexus.repository.view.Request;
+import org.sonatype.nexus.repository.view.Response;
+import org.sonatype.nexus.repository.view.Status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.sonatype.nexus.repository.composer.internal.ComposerProviderHandler.DO_NOT_REWRITE;
+import static org.sonatype.nexus.repository.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.sonatype.nexus.repository.http.HttpStatus.OK;
+
+public class ComposerProviderHandlerTest
+    extends TestSupport
+{
+  @Mock
+  private ComposerJsonProcessor composerJsonProcessor;
+
+  @Mock
+  private Context context;
+
+  @Mock
+  private Request request;
+
+  @Mock
+  private Response response;
+
+  @Mock
+  private Repository repository;
+
+  @Mock
+  private AttributesMap requestAttributes;
+
+  @Mock
+  private Payload payload;
+
+  @Mock
+  private Payload rewrittenPayload;
+
+  @Mock
+  private Status status;
+
+  private ComposerProviderHandler underTest;
+
+  @Before
+  public void setUp() throws Exception {
+    when(composerJsonProcessor.rewriteProviderJson(repository, payload)).thenReturn(rewrittenPayload);
+
+    when(context.getRequest()).thenReturn(request);
+    when(context.getRepository()).thenReturn(repository);
+    when(context.proceed()).thenReturn(response);
+
+    when(request.getAttributes()).thenReturn(requestAttributes);
+    when(requestAttributes.get(DO_NOT_REWRITE, String.class)).thenReturn("false");
+
+    when(response.getStatus()).thenReturn(status);
+    when(response.getPayload()).thenReturn(payload);
+    when(status.getCode()).thenReturn(OK);
+
+    underTest = new ComposerProviderHandler(composerJsonProcessor);
+  }
+
+  @Test
+  public void handleWithRewriteDisabled() throws Exception {
+    when(requestAttributes.get(DO_NOT_REWRITE, String.class)).thenReturn("true");
+
+    Response output = underTest.handle(context);
+
+    assertThat(output, is(response));
+    verifyNoMoreInteractions(composerJsonProcessor);
+  }
+
+  @Test
+  public void handleWithRewriteEnabled() throws Exception {
+    Response output = underTest.handle(context);
+
+    assertThat(output, is(not(response)));
+    assertThat(output.getPayload(), is(rewrittenPayload));
+
+    verify(composerJsonProcessor).rewriteProviderJson(repository, payload);
+  }
+
+  @Test
+  public void handleWithRewriteEnabledNotOK() throws Exception {
+    when(status.getCode()).thenReturn(INTERNAL_SERVER_ERROR);
+
+    Response output = underTest.handle(context);
+
+    assertThat(output, is(response));
+    verifyNoMoreInteractions(composerJsonProcessor);
+  }
+
+  @Test
+  public void handleWithRewriteEnabledNoPayload() throws Exception {
+    when(response.getPayload()).thenReturn(null);
+
+    Response output = underTest.handle(context);
+
+    assertThat(output, is(response));
+    verifyNoMoreInteractions(composerJsonProcessor);
+  }
+}

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyFacetImplTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyFacetImplTest.java
@@ -1,0 +1,305 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.common.collect.AttributesMap;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.cache.CacheInfo;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Payload;
+import org.sonatype.nexus.repository.view.Request;
+import org.sonatype.nexus.repository.view.Response;
+import org.sonatype.nexus.repository.view.ViewFacet;
+import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.LIST;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.PACKAGES;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.PROVIDER;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.ZIPBALL;
+
+public class ComposerProxyFacetImplTest
+    extends TestSupport
+{
+  private static final String LIST_PATH = "packages/list.json";
+
+  private static final String PACKAGES_PATH = "packages.json";
+
+  private static final String PROVIDER_PATH = "p/vendor/project.json";
+
+  private static final String ZIPBALL_PATH = "vendor/project/version/project-version.zip";
+
+  @Mock
+  private Repository repository;
+
+  @Mock
+  private Context context;
+
+  @Mock
+  private AttributesMap contextAttributes;
+
+  @Mock
+  private ComposerContentFacet composerContentFacet;
+
+  @Mock
+  private ViewFacet viewFacet;
+
+  @Mock
+  private ComposerJsonProcessor composerJsonProcessor;
+
+  @Mock
+  private Content content;
+
+  @Mock
+  private TokenMatcher.State state;
+
+  @Mock
+  private CacheInfo cacheInfo;
+
+  @Mock
+  private Request request;
+
+  @Mock
+  private Response response;
+
+  @Mock
+  private Payload payload;
+
+  private ComposerProxyFacetImpl underTest;
+
+  @Before
+  public void setUp() throws Exception {
+    underTest = new ComposerProxyFacetImpl(composerJsonProcessor);
+    underTest.attach(repository);
+
+    when(repository.facet(ComposerContentFacet.class)).thenReturn(composerContentFacet);
+    when(repository.facet(ViewFacet.class)).thenReturn(viewFacet);
+
+    when(context.getAttributes()).thenReturn(contextAttributes);
+    when(context.getRequest()).thenReturn(request);
+    when(context.getRepository()).thenReturn(repository);
+
+    when(response.getPayload()).thenReturn(payload);
+  }
+
+  @Test
+  public void getCachedContentPackages() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(PACKAGES);
+    when(composerContentFacet.get(PACKAGES_PATH)).thenReturn(content);
+
+    assertThat(underTest.getCachedContent(context), is(content));
+  }
+
+  @Test
+  public void getCachedContentList() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(LIST);
+    when(composerContentFacet.get(LIST_PATH)).thenReturn(content);
+
+    assertThat(underTest.getCachedContent(context), is(content));
+  }
+
+  @Test
+  public void getCachedContentProvider() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(PROVIDER);
+    when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
+
+    when(composerContentFacet.get(PROVIDER_PATH)).thenReturn(content);
+
+    when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
+        .put("vendor", "vendor")
+        .put("project", "project")
+        .build());
+
+    assertThat(underTest.getCachedContent(context), is(content));
+  }
+
+  @Test
+  public void getCachedContentZipball() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(ZIPBALL);
+    when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
+
+    when(composerContentFacet.get(ZIPBALL_PATH)).thenReturn(content);
+
+    when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
+        .put("vendor", "vendor")
+        .put("project", "project")
+        .put("version", "version")
+        .put("name", "project-version")
+        .build());
+
+    assertThat(underTest.getCachedContent(context), is(content));
+  }
+
+  @Test
+  public void indicateVerifiedPackages() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(PACKAGES);
+
+    underTest.indicateVerified(context, content, cacheInfo);
+
+    verify(composerContentFacet).setCacheInfo(PACKAGES_PATH, content, cacheInfo);
+  }
+
+  @Test
+  public void indicateVerifiedList() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(LIST);
+
+    underTest.indicateVerified(context, content, cacheInfo);
+
+    verify(composerContentFacet).setCacheInfo(LIST_PATH, content, cacheInfo);
+  }
+
+  @Test
+  public void indicateVerifiedProvider() throws Exception {
+    when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
+    when(contextAttributes.require(AssetKind.class)).thenReturn(PROVIDER);
+
+    when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
+        .put("vendor", "vendor")
+        .put("project", "project")
+        .build());
+
+    underTest.indicateVerified(context, content, cacheInfo);
+
+    verify(composerContentFacet).setCacheInfo(PROVIDER_PATH, content, cacheInfo);
+  }
+
+  @Test
+  public void indicateVerifiedZipball() throws Exception {
+    when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
+    when(contextAttributes.require(AssetKind.class)).thenReturn(ZIPBALL);
+
+    when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
+        .put("vendor", "vendor")
+        .put("project", "project")
+        .put("version", "version")
+        .put("name", "project-version")
+        .build());
+
+    underTest.indicateVerified(context, content, cacheInfo);
+
+    verify(composerContentFacet).setCacheInfo(ZIPBALL_PATH, content, cacheInfo);
+  }
+
+  @Test
+  public void storePackages() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(PACKAGES);
+    when(composerContentFacet.put(PACKAGES_PATH, content, PACKAGES)).thenReturn(content);
+
+    when(viewFacet.dispatch(any(Request.class), eq(context))).thenReturn(response);
+    when(composerJsonProcessor.generatePackagesJson(repository, payload)).thenReturn(content);
+
+    assertThat(underTest.store(context, content), is(content));
+
+    verify(composerContentFacet).put(PACKAGES_PATH, content, PACKAGES);
+  }
+
+  @Test
+  public void storeList() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(LIST);
+    when(composerContentFacet.put(LIST_PATH, content, LIST)).thenReturn(content);
+
+    assertThat(underTest.store(context, content), is(content));
+
+    verify(composerContentFacet).put(LIST_PATH, content, LIST);
+  }
+
+  @Test
+  public void storeProvider() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(PROVIDER);
+    when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
+
+    when(composerContentFacet.put(PROVIDER_PATH, content, PROVIDER)).thenReturn(content);
+
+    when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
+        .put("vendor", "vendor")
+        .put("project", "project")
+        .build());
+
+    assertThat(underTest.store(context, content), is(content));
+
+    verify(composerContentFacet).put(PROVIDER_PATH, content, PROVIDER);
+  }
+
+  @Test
+  public void storeZipball() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(ZIPBALL);
+    when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
+
+    when(composerContentFacet.put(ZIPBALL_PATH, content, ZIPBALL)).thenReturn(content);
+
+    when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
+        .put("vendor", "vendor")
+        .put("project", "project")
+        .put("version", "version")
+        .put("name", "project-version")
+        .build());
+
+    assertThat(underTest.store(context, content), is(content));
+
+    verify(composerContentFacet).put(ZIPBALL_PATH, content, ZIPBALL);
+  }
+
+  @Test
+  public void getUrlPackages() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(LIST);
+    when(request.getPath()).thenReturn("/" + PACKAGES_PATH);
+
+    assertThat(underTest.getUrl(context), is(PACKAGES_PATH));
+  }
+
+  @Test
+  public void getUrlList() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(LIST);
+    when(request.getPath()).thenReturn("/" + LIST_PATH);
+
+    assertThat(underTest.getUrl(context), is(LIST_PATH));
+  }
+
+  @Test
+  public void getUrlProvider() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(LIST);
+    when(request.getPath()).thenReturn("/" + PROVIDER_PATH);
+
+    assertThat(underTest.getUrl(context), is(PROVIDER_PATH));
+  }
+
+  @Test
+  public void getUrlZipball() throws Exception {
+    when(contextAttributes.require(AssetKind.class)).thenReturn(ZIPBALL);
+    when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
+
+    when(viewFacet.dispatch(any(Request.class), eq(context))).thenReturn(response);
+    when(composerJsonProcessor.getDistUrl("vendor", "project", "version", payload)).thenReturn("distUrl");
+
+    when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
+        .put("vendor", "vendor")
+        .put("project", "project")
+        .put("version", "version")
+        .put("name", "project-version")
+        .build());
+
+    assertThat(underTest.getUrl(context), is("distUrl"));
+  }
+}

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromList.list.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromList.list.json
@@ -1,0 +1,7 @@
+{
+  "packageNames": [
+    "vendor1\/project1",
+    "vendor2\/project2",
+    "vendor3\/project3"
+  ]
+}

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromList.packages.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromList.packages.json
@@ -1,0 +1,14 @@
+{
+  "providers-url": "http://nexus.repo/base/repo/p/%package%.json",
+  "providers": {
+    "vendor2/project2": {
+      "sha256": null
+    },
+    "vendor1/project1": {
+      "sha256": null
+    },
+    "vendor3/project3": {
+      "sha256": null
+    }
+  }
+}

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/getDistUrl.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/getDistUrl.json
@@ -1,0 +1,66 @@
+{
+  "packages": {
+    "vendor1\/project1": {
+      "1.0.0": {
+        "name": "vendor1\/project1",
+        "description": "Description 1",
+        "keywords": [],
+        "homepage": "",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0",
+        "license": [
+          "MIT"
+        ],
+        "authors": [
+          {
+            "name": "Author 1",
+            "homepage": "http:\/\/example.com/author1"
+          }
+        ],
+        "source": {
+          "type": "git",
+          "url": "https:\/\/git.example.com\/vendor1\/project1.git",
+          "reference": "48954c0fa210437795be418e708b379598333d0a"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https:\/\/git.example.com\/zipball\/48954c0fa210437795be418e708b379598333d0a",
+          "reference": "48954c0fa210437795be418e708b379598333d0a",
+          "shasum": ""
+        },
+        "time": "2018-01-09T15:53:01+00:00",
+        "uid": 1
+      },
+      "2.0.0": {
+        "name": "vendor1\/project1",
+        "description": "Description 1",
+        "keywords": [],
+        "homepage": "",
+        "version": "2.0.0",
+        "version_normalized": "2.0.0",
+        "license": [
+          "MIT"
+        ],
+        "authors": [
+          {
+            "name": "Author 1",
+            "homepage": "http:\/\/example.com/author1"
+          }
+        ],
+        "source": {
+          "type": "git",
+          "url": "https:\/\/git.example.com\/vendor1\/project1.git",
+          "reference": "418e708b379598333d0a48954c0fa210437795be"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https:\/\/git.example.com\/zipball\/418e708b379598333d0a48954c0fa210437795be",
+          "reference": "418e708b379598333d0a48954c0fa210437795be",
+          "shasum": ""
+        },
+        "time": "2018-01-09T15:53:01+00:00",
+        "uid": 1
+      }
+    }
+  }
+}

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/rewriteProviderJson.input.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/rewriteProviderJson.input.json
@@ -1,0 +1,66 @@
+{
+  "packages": {
+    "vendor1\/project1": {
+      "branch1": {
+        "name": "vendor1\/project1",
+        "description": "Description 1",
+        "keywords": [],
+        "homepage": "",
+        "version": "branch1",
+        "version_normalized": "branch1",
+        "license": [
+          "MIT"
+        ],
+        "authors": [
+          {
+            "name": "Author 1",
+            "homepage": "http:\/\/example.com/author1"
+          }
+        ],
+        "source": {
+          "type": "git",
+          "url": "https:\/\/git.example.com\/vendor1\/project1.git",
+          "reference": "48954c0fa210437795be418e708b379598333d0a"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https:\/\/git.example.com\/zipball\/48954c0fa210437795be418e708b379598333d0a",
+          "reference": "48954c0fa210437795be418e708b379598333d0a",
+          "shasum": ""
+        },
+        "time": "2018-01-09T15:53:01+00:00",
+        "uid": 1
+      },
+      "branch2": {
+        "name": "vendor2\/project2",
+        "description": "Description 2",
+        "keywords": [],
+        "homepage": "",
+        "version": "branch2",
+        "version_normalized": "branch2",
+        "license": [
+          "MIT"
+        ],
+        "authors": [
+          {
+            "name": "Author 2",
+            "homepage": "http:\/\/example.com/author2"
+          }
+        ],
+        "source": {
+          "type": "git",
+          "url": "https:\/\/git.example.com\/vendor2\/project1.git",
+          "reference": "be418e708b379598333d0a48954c0fa210437795"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https:\/\/git.example.com\/zipball\/be418e708b379598333d0a48954c0fa210437795",
+          "reference": "be418e708b379598333d0a48954c0fa210437795",
+          "shasum": ""
+        },
+        "time": "2018-01-09T15:53:01+00:00",
+        "uid": 2
+      }
+    }
+  }
+}

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/rewriteProviderJson.output.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/rewriteProviderJson.output.json
@@ -1,0 +1,56 @@
+{
+  "packages": {
+    "vendor1/project1": {
+      "branch1": {
+        "name": "vendor1/project1",
+        "description": "Description 1",
+        "keywords": [],
+        "homepage": "",
+        "version": "branch1",
+        "version_normalized": "branch1",
+        "license": [
+          "MIT"
+        ],
+        "authors": [
+          {
+            "name": "Author 1",
+            "homepage": "http://example.com/author1"
+          }
+        ],
+        "dist": {
+          "type": "zip",
+          "url": "http://nexus.repo/base/repo/vendor1/project1/branch1/vendor1-project1-branch1.zip",
+          "reference": "48954c0fa210437795be418e708b379598333d0a",
+          "shasum": ""
+        },
+        "time": "2018-01-09T15:53:01+00:00",
+        "uid": 1
+      },
+      "branch2": {
+        "name": "vendor2/project2",
+        "description": "Description 2",
+        "keywords": [],
+        "homepage": "",
+        "version": "branch2",
+        "version_normalized": "branch2",
+        "license": [
+          "MIT"
+        ],
+        "authors": [
+          {
+            "name": "Author 2",
+            "homepage": "http://example.com/author2"
+          }
+        ],
+        "dist": {
+          "type": "zip",
+          "url": "http://nexus.repo/base/repo/vendor1/project1/branch2/vendor1-project1-branch2.zip",
+          "reference": "be418e708b379598333d0a48954c0fa210437795",
+          "shasum": ""
+        },
+        "time": "2018-01-09T15:53:01+00:00",
+        "uid": 2
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves #1 as best we can (for now) without coming up with a way to run integration tests in third-party plugins such as this one.

Note that this isn't going to give us perfect test coverage, but it should at least cover a good portion of the most likely things to regress going forward.