### PR TITLE
composer hosted packages.json duplicated key

### DIFF
--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessor.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessor.java
@@ -18,7 +18,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -96,7 +98,7 @@ public class ComposerJsonProcessor
   public Content generatePackagesFromList(final Repository repository, final Payload payload) throws IOException {
     // TODO: Parse using JSON tokens rather than loading all this into memory, it "should" work but I'd be careful.
     Map<String, Object> listJson = parseJson(payload);
-    return buildPackagesJson(repository, (Collection<String>) listJson.get(PACKAGE_NAMES_KEY));
+    return buildPackagesJson(repository, new LinkedHashSet<>((Collection<String>) listJson.get(PACKAGE_NAMES_KEY)));
   }
 
   /**
@@ -108,13 +110,13 @@ public class ComposerJsonProcessor
       throws IOException
   {
     return buildPackagesJson(repository, StreamSupport.stream(components.spliterator(), false)
-        .map(component -> component.group() + "/" + component.name()).collect(Collectors.toList()));
+        .map(component -> component.group() + "/" + component.name()).collect(Collectors.toSet()));
   }
 
   /**
    * Builds a packages.json file as a {@code Content} instance containing the actual JSON for the given providers.
    */
-  private Content buildPackagesJson(final Repository repository, final Collection<String> names) throws IOException {
+  private Content buildPackagesJson(final Repository repository, final Set<String> names) throws IOException {
     Map<String, Object> packagesJson = new LinkedHashMap<>();
     packagesJson.put(PROVIDERS_URL_KEY, repository.getUrl() + PACKAGE_JSON_PATH);
     packagesJson.put(PROVIDERS_KEY, names.stream()

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
@@ -79,12 +79,18 @@ public class ComposerJsonProcessorTest
 
     when(component1.group()).thenReturn("vendor1");
     when(component1.name()).thenReturn("project1");
+    when(component1.version()).thenReturn("version1");
 
     when(component2.group()).thenReturn("vendor2");
     when(component2.name()).thenReturn("project2");
+    when(component2.version()).thenReturn("version2");
+
+    when(component3.group()).thenReturn("vendor1");
+    when(component3.name()).thenReturn("project1");
+    when(component3.version()).thenReturn("version2");
 
     ComposerJsonProcessor underTest = new ComposerJsonProcessor();
-    Content output = underTest.generatePackagesFromComponents(repository, asList(component1, component2));
+    Content output = underTest.generatePackagesFromComponents(repository, asList(component1, component2, component3));
 
     assertEquals(packagesJson, readStreamToString(output.openInputStream()), true);
   }


### PR DESCRIPTION
Fixes #15 by using a `Set<>` rather than a `List<>` for names included in a `packages.json`. Also changed the signature to require `Set<>` instead of `Collection<>`.

The existing implementation fails on components with the same group (vendor) and name information because of duplicate keys when collecting to a `Map`, which makes hosted effectively useless in its current state.

Also adds a short unit test to verify that we handle duplicates correctly going forward when building the `packages.json`.