### PR TITLE
Generate static provider.json content using composer.json files

### DIFF
--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerAttributes.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerAttributes.java
@@ -50,4 +50,8 @@ public final class ComposerAttributes
   public static final String P_SUPPORT_DOCS = "support_docs";
 
   public static final String P_SUPPORT_RSS = "support_rss";
+
+  public static final String P_VENDOR = "vendor";
+
+  public static final String P_PROJECT = "project";
 }

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacet.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacet.java
@@ -33,6 +33,8 @@ public interface ComposerHostedFacet
 
   Content getProviderJson(String vendor, String project) throws IOException;
 
+  void rebuildProviderJson(String vendor, String project) throws IOException;
+
   @Nullable
   Content getZipball(String path) throws IOException;
 }

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacet.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacet.java
@@ -27,7 +27,7 @@ import org.sonatype.nexus.repository.view.Payload;
 public interface ComposerHostedFacet
     extends Facet
 {
-  void upload(String path, Payload payload) throws IOException;
+  void upload(String vendor, String project, String version, Payload payload) throws IOException;
 
   Content getPackagesJson() throws IOException;
 

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
@@ -69,7 +69,7 @@ public class ComposerHostedFacetImpl
   @TransactionalTouchMetadata
   public Content getProviderJson(final String vendor, final String project) throws IOException {
     StorageTx tx = UnitOfWork.currentTx();
-    return composerJsonProcessor.buildProviderJson(getRepository(),
+    return composerJsonProcessor.buildProviderJson(getRepository(), tx,
         tx.findComponents(buildQuery(vendor, project), singletonList(getRepository())));
   }
 

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
@@ -48,8 +48,10 @@ public class ComposerHostedFacetImpl
   }
 
   @Override
-  public void upload(final String path, final Payload payload) throws IOException {
-    content().put(path, payload, AssetKind.ZIPBALL);
+  public void upload(final String vendor, final String project, final String version, final Payload payload)
+      throws IOException
+  {
+    content().put(ComposerPathUtils.buildZipballPath(vendor, project, version), payload, AssetKind.ZIPBALL);
   }
 
   @Override

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataFacet.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataFacet.java
@@ -1,0 +1,25 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import org.sonatype.nexus.repository.Facet;
+
+/**
+ * Tagging interface indicating that a facet is an implementation of a {@code ComposerHostedMetadataFacet}. This facet
+ * is responsible for maintaining the internal metadata (currently just the provider.json file).
+ */
+@Facet.Exposed
+public interface ComposerHostedMetadataFacet
+    extends Facet
+{
+}

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataFacetImpl.java
@@ -1,0 +1,121 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.sonatype.nexus.common.event.EventManager;
+import org.sonatype.nexus.common.stateguard.Guarded;
+import org.sonatype.nexus.repository.FacetSupport;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.AssetCreatedEvent;
+import org.sonatype.nexus.repository.storage.AssetDeletedEvent;
+import org.sonatype.nexus.repository.storage.AssetEvent;
+import org.sonatype.nexus.repository.storage.AssetUpdatedEvent;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+import com.google.common.eventbus.AllowConcurrentEvents;
+import com.google.common.eventbus.Subscribe;
+import org.joda.time.DateTime;
+
+import static jline.internal.Preconditions.checkNotNull;
+import static org.joda.time.DateTime.now;
+import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STARTED;
+import static org.sonatype.nexus.repository.composer.internal.ComposerAttributes.P_PROJECT;
+import static org.sonatype.nexus.repository.composer.internal.ComposerAttributes.P_VENDOR;
+import static org.sonatype.nexus.repository.storage.AssetEntityAdapter.P_ASSET_KIND;
+
+/**
+ * Concrete implementation of {@code ComposerHostedMetadataFacet} using events. Essentially a stripped-down form of the
+ * mechanism behind the Yum createrepo implementation in our internal codebase.
+ */
+@Named
+public class ComposerHostedMetadataFacetImpl
+    extends FacetSupport
+    implements ComposerHostedMetadataFacet
+{
+  private final EventManager eventManager;
+
+  @Inject
+  public ComposerHostedMetadataFacetImpl(final EventManager eventManager)
+  {
+    this.eventManager = checkNotNull(eventManager);
+  }
+
+  @Subscribe
+  @Guarded(by = STARTED)
+  @AllowConcurrentEvents
+  public void on(final AssetDeletedEvent deleted) {
+    if (matchesRepository(deleted) && isEventRelevant(deleted)) {
+      invalidateMetadata(deleted);
+    }
+  }
+
+  @Subscribe
+  @Guarded(by = STARTED)
+  @AllowConcurrentEvents
+  public void on(final AssetCreatedEvent created) {
+    if (matchesRepository(created) && isEventRelevant(created)) {
+      invalidateMetadata(created);
+    }
+  }
+
+  @Subscribe
+  @Guarded(by = STARTED)
+  @AllowConcurrentEvents
+  public void on(final AssetUpdatedEvent updated) {
+    if (matchesRepository(updated) && isEventRelevant(updated) && hasBlobBeenUpdated(updated)) {
+      invalidateMetadata(updated);
+    }
+  }
+
+  @Subscribe
+  @Guarded(by = STARTED)
+  public void on(final ComposerHostedMetadataInvalidationEvent event) throws IOException {
+    if (getRepository().getName().equals(event.getRepositoryName())) {
+      ComposerHostedFacet hostedFacet = getRepository().facet(ComposerHostedFacet.class);
+      UnitOfWork.begin(getRepository().facet(StorageFacet.class).txSupplier());
+      try {
+        hostedFacet.rebuildProviderJson(event.getVendor(), event.getProject());
+      }
+      finally {
+        UnitOfWork.end();
+      }
+    }
+  }
+
+  private void invalidateMetadata(final AssetEvent assetEvent) {
+    Asset asset = assetEvent.getAsset();
+    String vendor = asset.formatAttributes().require(P_VENDOR, String.class);
+    String project = asset.formatAttributes().require(P_PROJECT, String.class);
+    eventManager.post(new ComposerHostedMetadataInvalidationEvent(getRepository().getName(), vendor, project));
+  }
+
+  private boolean matchesRepository(final AssetEvent assetEvent) {
+    return assetEvent.isLocal() && getRepository().getName().equals(assetEvent.getRepositoryName());
+  }
+
+  private boolean isEventRelevant(final AssetEvent event) {
+    return AssetKind.ZIPBALL.name().equals(event.getAsset().formatAttributes().get(P_ASSET_KIND, String.class));
+  }
+
+  private boolean hasBlobBeenUpdated(final AssetUpdatedEvent updated) {
+    DateTime blobUpdated = updated.getAsset().blobUpdated();
+    DateTime oneMinuteAgo = now().minusMinutes(1);
+    return blobUpdated == null || blobUpdated.isAfter(oneMinuteAgo);
+  }
+}

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataInvalidationEvent.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataInvalidationEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Event fired when metadata (the provider.json) for a particular vendor/project in a Composer hosted repository is no
+ * longer valid. This happens when an asset is created, updated, or deleted and the corresponding provider.json must be
+ * rebuilt.
+ */
+public class ComposerHostedMetadataInvalidationEvent
+{
+  private final String repositoryName;
+
+  private final String vendor;
+
+  private final String project;
+
+  public ComposerHostedMetadataInvalidationEvent(final String repositoryName,
+                                                 final String vendor,
+                                                 final String project)
+  {
+    this.repositoryName = checkNotNull(repositoryName);
+    this.vendor = checkNotNull(vendor);
+    this.project = checkNotNull(project);
+  }
+
+  public String getRepositoryName() {
+    return repositoryName;
+  }
+
+  public String getVendor() {
+    return vendor;
+  }
+
+  public String getProject() {
+    return project;
+  }
+}

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedRecipe.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedRecipe.groovy
@@ -45,6 +45,9 @@ class ComposerHostedRecipe
   Provider<ComposerHostedFacet> hostedFacet
 
   @Inject
+  Provider<ComposerHostedMetadataFacet> hostedMetadataFacet
+
+  @Inject
   ComposerHostedUploadHandler uploadHandler
 
   @Inject
@@ -62,6 +65,7 @@ class ComposerHostedRecipe
     repository.attach(configure(viewFacet.get()))
     repository.attach(componentMaintenanceFacet.get())
     repository.attach(hostedFacet.get())
+    repository.attach(hostedMetadataFacet.get())
     repository.attach(storageFacet.get())
     repository.attach(searchFacet.get())
     repository.attach(attributesFacet.get())

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandler.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandler.java
@@ -48,6 +48,8 @@ public class ComposerHostedUploadHandler
     ComposerHostedFacet hostedFacet = repository.facet(ComposerHostedFacet.class);
 
     hostedFacet.upload(vendor, project, version, payload);
+    hostedFacet.rebuildProviderJson(vendor, project);
+
     return HttpResponses.ok();
   }
 }

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandler.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandler.java
@@ -48,8 +48,6 @@ public class ComposerHostedUploadHandler
     ComposerHostedFacet hostedFacet = repository.facet(ComposerHostedFacet.class);
 
     hostedFacet.upload(vendor, project, version, payload);
-    hostedFacet.rebuildProviderJson(vendor, project);
-
     return HttpResponses.ok();
   }
 }

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandler.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandler.java
@@ -37,14 +37,17 @@ public class ComposerHostedUploadHandler
   @Nonnull
   @Override
   public Response handle(@Nonnull final Context context) throws Exception {
-    String path = ComposerPathUtils.buildZipballPath(context);
+    String vendor = ComposerPathUtils.getVendorToken(context);
+    String project = ComposerPathUtils.getProjectToken(context);
+    String version = ComposerPathUtils.getVersionToken(context);
+
     Request request = checkNotNull(context.getRequest());
     Payload payload = checkNotNull(request.getPayload());
 
     Repository repository = context.getRepository();
     ComposerHostedFacet hostedFacet = repository.facet(ComposerHostedFacet.class);
 
-    hostedFacet.upload(path, payload);
+    hostedFacet.upload(vendor, project, version, payload);
     return HttpResponses.ok();
   }
 }

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandler.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandler.java
@@ -25,6 +25,9 @@ import org.sonatype.nexus.repository.view.Request;
 import org.sonatype.nexus.repository.view.Response;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sonatype.nexus.repository.composer.internal.ComposerPathUtils.getProjectToken;
+import static org.sonatype.nexus.repository.composer.internal.ComposerPathUtils.getVendorToken;
+import static org.sonatype.nexus.repository.composer.internal.ComposerPathUtils.getVersionToken;
 
 /**
  * Upload handler for Composer hosted repositories.
@@ -37,9 +40,9 @@ public class ComposerHostedUploadHandler
   @Nonnull
   @Override
   public Response handle(@Nonnull final Context context) throws Exception {
-    String vendor = ComposerPathUtils.getVendorToken(context);
-    String project = ComposerPathUtils.getProjectToken(context);
-    String version = ComposerPathUtils.getVersionToken(context);
+    String vendor = getVendorToken(context);
+    String project = getProjectToken(context);
+    String version = getVersionToken(context);
 
     Request request = checkNotNull(context.getRequest());
     Payload payload = checkNotNull(request.getPayload());

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonExtractor.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonExtractor.java
@@ -74,12 +74,19 @@ public class ComposerJsonExtractor
    */
   private Map<String, Object> processEntry(final ArchiveInputStream stream, final ArchiveEntry entry) throws IOException
   {
-    String name = entry.getName();
-    int filenameIndex = name.indexOf("/composer.json");
-    int separatorIndex = name.indexOf("/");
-    if (filenameIndex >= 0 && filenameIndex == separatorIndex) {
+    if (isComposerJsonFilename(entry.getName())) {
       return mapper.readValue(stream, typeReference);
     }
     return Collections.emptyMap();
+  }
+
+  /**
+   * Returns a boolean indicating if the associated file path (from an archive file) represents the {@code
+   * composer.json} file.
+   */
+  private boolean isComposerJsonFilename(final String entryName) {
+    int filenameIndex = entryName.indexOf("/composer.json");
+    int separatorIndex = entryName.indexOf("/");
+    return filenameIndex >= 0 && filenameIndex == separatorIndex;
   }
 }

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonExtractor.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonExtractor.java
@@ -1,0 +1,85 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.goodies.common.ComponentSupport;
+import org.sonatype.nexus.blobstore.api.Blob;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+
+/**
+ * Utility class for extracting the contents of a package's {@code composer.json} file and returning it as a map.
+ */
+@Named
+@Singleton
+public class ComposerJsonExtractor
+    extends ComponentSupport
+{
+  private final TypeReference<Map<String, Object>> typeReference = new TypeReference<Map<String, Object>>() { };
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  private final ArchiveStreamFactory archiveStreamFactory = new ArchiveStreamFactory();
+
+  /**
+   * Extracts the contents for the first matching {@code composer.json} file (of which there should only be one) as a
+   * map representing the parsed JSON content. If no such file is found then an empty map is returned.
+   */
+  public Map<String, Object> extractFromZip(final Blob blob) throws IOException {
+    try (InputStream is = blob.getInputStream()) {
+      try (ArchiveInputStream ais = archiveStreamFactory.createArchiveInputStream(ArchiveStreamFactory.ZIP, is)) {
+        ArchiveEntry entry = ais.getNextEntry();
+        while (entry != null) {
+          Map<String, Object> contents = processEntry(ais, entry);
+          if (!contents.isEmpty()) {
+            return contents;
+          }
+          entry = ais.getNextEntry();
+        }
+      }
+      return Collections.emptyMap();
+    }
+    catch (ArchiveException e) {
+      throw new IOException("Error reading from archive", e);
+    }
+  }
+
+  /**
+   * Processes a single entry in the archive. If the entry is the composer.json then the attributes will be extracted.
+   * If not, the entry is skipped.
+   */
+  private Map<String, Object> processEntry(final ArchiveInputStream stream, final ArchiveEntry entry) throws IOException
+  {
+    String name = entry.getName();
+    int filenameIndex = name.indexOf("/composer.json");
+    int separatorIndex = name.indexOf("/");
+    if (filenameIndex >= 0 && filenameIndex == separatorIndex) {
+      return mapper.readValue(stream, typeReference);
+    }
+    return Collections.emptyMap();
+  }
+}

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerPathUtils.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerPathUtils.java
@@ -53,7 +53,7 @@ public final class ComposerPathUtils
   }
 
   /**
-   * Returns the version token from a path in a context. The project token must be present or the operation will fail.
+   * Returns the version token from a path in a context. The version token must be present or the operation will fail.
    */
   public static String getVersionToken(final Context context) {
     TokenMatcher.State state = context.getAttributes().require(TokenMatcher.State.class);

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerPathUtils.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerPathUtils.java
@@ -53,6 +53,14 @@ public final class ComposerPathUtils
   }
 
   /**
+   * Returns the version token from a path in a context. The project token must be present or the operation will fail.
+   */
+  public static String getVersionToken(final Context context) {
+    TokenMatcher.State state = context.getAttributes().require(TokenMatcher.State.class);
+    return checkNotNull(state.getTokens().get(VERSION_TOKEN));
+  }
+
+  /**
    * Builds the path to a zipball based on the path contained in a particular context. For download routes the full
    * path including the name token will be present and will be constructed accordingly. For upload routes the full
    * path will not be known because the filename will not be present, so the name portion will be constructed from

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImplTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImplTest.java
@@ -62,6 +62,9 @@ import static org.sonatype.nexus.repository.composer.internal.AssetKind.LIST;
 import static org.sonatype.nexus.repository.composer.internal.AssetKind.PACKAGES;
 import static org.sonatype.nexus.repository.composer.internal.AssetKind.PROVIDER;
 import static org.sonatype.nexus.repository.composer.internal.AssetKind.ZIPBALL;
+import static org.sonatype.nexus.repository.composer.internal.ComposerAttributes.P_PROJECT;
+import static org.sonatype.nexus.repository.composer.internal.ComposerAttributes.P_VENDOR;
+import static org.sonatype.nexus.repository.composer.internal.ComposerAttributes.P_VERSION;
 import static org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter.P_NAME;
 
 public class ComposerContentFacetImplTest
@@ -281,6 +284,9 @@ public class ComposerContentFacetImplTest
 
     if (ZIPBALL.equals(assetKind)) {
       verify(formatAttributes).clear();
+      verify(formatAttributes).set(P_VENDOR, "vendor");
+      verify(formatAttributes).set(P_PROJECT, "project");
+      verify(formatAttributes).set(P_VERSION, "version");
       verify(composerFormatAttributesExtractor).extractFromZip(tempBlob, formatAttributes);
     }
 

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImplTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImplTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.PROVIDER;
 import static org.sonatype.nexus.repository.composer.internal.AssetKind.ZIPBALL;
 
 public class ComposerHostedFacetImplTest
@@ -47,6 +48,8 @@ public class ComposerHostedFacetImplTest
   private static final String VERSION = "version";
 
   private static final String ZIPBALL_PATH = "vendor/project/version/vendor-project-version.zip";
+
+  private static final String PROVIDER_PATH = "p/vendor/project.json";
 
   @Mock
   private Repository repository;
@@ -114,10 +117,17 @@ public class ComposerHostedFacetImplTest
 
   @Test
   public void testGetProviderJson() throws Exception {
+    when(composerContentFacet.get(PROVIDER_PATH)).thenReturn(content);
+    assertThat(underTest.getProviderJson(VENDOR, PROJECT), is(content));
+  }
+
+  @Test
+  public void testBuildProviderJson() throws Exception {
     when(underTest.buildQuery(VENDOR, PROJECT)).thenReturn(query);
     when(tx.findComponents(eq(query), eq(singletonList(repository)))).thenReturn(components);
     when(composerJsonProcessor.buildProviderJson(repository, tx, components)).thenReturn(content);
-    assertThat(underTest.getProviderJson(VENDOR, PROJECT), is(content));
+    underTest.rebuildProviderJson(VENDOR, PROJECT);
+    verify(composerContentFacet).put(PROVIDER_PATH, content, PROVIDER);
   }
 
   @Test

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImplTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImplTest.java
@@ -114,7 +114,7 @@ public class ComposerHostedFacetImplTest
   public void testGetProviderJson() throws Exception {
     when(underTest.buildQuery(VENDOR, PROJECT)).thenReturn(query);
     when(tx.findComponents(eq(query), eq(singletonList(repository)))).thenReturn(components);
-    when(composerJsonProcessor.buildProviderJson(repository, components)).thenReturn(content);
+    when(composerJsonProcessor.buildProviderJson(repository, tx, components)).thenReturn(content);
     assertThat(underTest.getProviderJson(VENDOR, PROJECT), is(content));
   }
 

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImplTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImplTest.java
@@ -40,11 +40,13 @@ import static org.sonatype.nexus.repository.composer.internal.AssetKind.ZIPBALL;
 public class ComposerHostedFacetImplTest
     extends TestSupport
 {
-  private static final String VENDOR = "test-vendor";
+  private static final String VENDOR = "vendor";
 
-  private static final String PROJECT = "test-project";
+  private static final String PROJECT = "project";
 
-  private static final String ZIPBALL_PATH = "test-vendor/test-project/version/vendor-project-version.zip";
+  private static final String VERSION = "version";
+
+  private static final String ZIPBALL_PATH = "vendor/project/version/vendor-project-version.zip";
 
   @Mock
   private Repository repository;
@@ -93,7 +95,7 @@ public class ComposerHostedFacetImplTest
 
   @Test
   public void testUpload() throws Exception {
-    underTest.upload(ZIPBALL_PATH, payload);
+    underTest.upload(VENDOR, PROJECT, VERSION, payload);
     verify(composerContentFacet).put(ZIPBALL_PATH, payload, ZIPBALL);
   }
 

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataFacetImplTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataFacetImplTest.java
@@ -1,0 +1,270 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
+import org.sonatype.nexus.common.event.EventManager;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.AssetCreatedEvent;
+import org.sonatype.nexus.repository.storage.AssetDeletedEvent;
+import org.sonatype.nexus.repository.storage.AssetUpdatedEvent;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.repository.storage.StorageTx;
+
+import com.google.common.base.Supplier;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.PACKAGES;
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.ZIPBALL;
+import static org.sonatype.nexus.repository.composer.internal.ComposerAttributes.P_PROJECT;
+import static org.sonatype.nexus.repository.composer.internal.ComposerAttributes.P_VENDOR;
+import static org.sonatype.nexus.repository.storage.AssetEntityAdapter.P_ASSET_KIND;
+
+public class ComposerHostedMetadataFacetImplTest
+    extends TestSupport
+{
+  private static final String REPOSITORY_NAME = "test-repository-name";
+
+  private static final String VENDOR = "test-vendor";
+
+  private static final String PROJECT = "test-project";
+
+  @Mock
+  private Repository repository;
+
+  @Mock
+  private EventManager eventManager;
+
+  @Mock
+  private ComposerHostedFacet hostedFacet;
+
+  @Mock
+  private StorageFacet storageFacet;
+
+  @Mock
+  Supplier<StorageTx> txSupplier;
+
+  @Mock
+  private StorageTx storageTx;
+
+  @Mock
+  private Asset asset;
+
+  @Mock
+  private NestedAttributesMap formatAttributes;
+
+  @Mock
+  private AssetDeletedEvent assetDeletedEvent;
+
+  @Mock
+  private AssetUpdatedEvent assetUpdatedEvent;
+
+  @Mock
+  private AssetCreatedEvent assetCreatedEvent;
+
+  @Mock
+  private ComposerHostedMetadataInvalidationEvent composerHostedMetadataInvalidationEvent;
+
+  private ComposerHostedMetadataFacetImpl underTest;
+
+  @Before
+  public void setUp() throws Exception {
+    when(repository.getName()).thenReturn(REPOSITORY_NAME);
+    when(repository.facet(ComposerHostedFacet.class)).thenReturn(hostedFacet);
+    when(repository.facet(StorageFacet.class)).thenReturn(storageFacet);
+
+    when(assetDeletedEvent.getRepositoryName()).thenReturn(REPOSITORY_NAME);
+    when(assetDeletedEvent.getAsset()).thenReturn(asset);
+    when(assetDeletedEvent.isLocal()).thenReturn(true);
+
+    when(assetUpdatedEvent.getRepositoryName()).thenReturn(REPOSITORY_NAME);
+    when(assetUpdatedEvent.getAsset()).thenReturn(asset);
+    when(assetUpdatedEvent.isLocal()).thenReturn(true);
+
+    when(assetCreatedEvent.getRepositoryName()).thenReturn(REPOSITORY_NAME);
+    when(assetCreatedEvent.getAsset()).thenReturn(asset);
+    when(assetCreatedEvent.isLocal()).thenReturn(true);
+
+    when(composerHostedMetadataInvalidationEvent.getRepositoryName()).thenReturn(REPOSITORY_NAME);
+    when(composerHostedMetadataInvalidationEvent.getVendor()).thenReturn(VENDOR);
+    when(composerHostedMetadataInvalidationEvent.getProject()).thenReturn(PROJECT);
+
+    when(asset.formatAttributes()).thenReturn(formatAttributes);
+
+    when(formatAttributes.require(P_VENDOR, String.class)).thenReturn(VENDOR);
+    when(formatAttributes.require(P_PROJECT, String.class)).thenReturn(PROJECT);
+    when(formatAttributes.get(P_ASSET_KIND, String.class)).thenReturn(ZIPBALL.name());
+
+    when(storageFacet.txSupplier()).thenReturn(txSupplier);
+    when(txSupplier.get()).thenReturn(storageTx);
+
+    underTest = new ComposerHostedMetadataFacetImpl(eventManager);
+    underTest.attach(repository);
+  }
+
+  @Test
+  public void testAssetDeletedEventWithDifferentRepository() {
+    when(assetDeletedEvent.getRepositoryName()).thenReturn("other-repository");
+
+    underTest.on(assetDeletedEvent);
+
+    verify(eventManager, never()).post(any(ComposerHostedMetadataInvalidationEvent.class));
+  }
+
+  @Test
+  public void testAssetDeletedEventWithDifferentNode() {
+    when(assetDeletedEvent.isLocal()).thenReturn(false);
+
+    underTest.on(assetDeletedEvent);
+
+    verify(eventManager, never()).post(any(ComposerHostedMetadataInvalidationEvent.class));
+  }
+
+  @Test
+  public void testAssetDeletedEventWithNonZipballAsset() {
+    when(formatAttributes.get(P_ASSET_KIND, String.class)).thenReturn(PACKAGES.name());
+
+    underTest.on(assetDeletedEvent);
+
+    verify(eventManager, never()).post(any(ComposerHostedMetadataInvalidationEvent.class));
+  }
+
+  @Test
+  public void testAssetDeletedEvent() {
+    underTest.on(assetDeletedEvent);
+
+    ArgumentCaptor<ComposerHostedMetadataInvalidationEvent> captor = ArgumentCaptor
+        .forClass(ComposerHostedMetadataInvalidationEvent.class);
+
+    verify(eventManager).post(captor.capture());
+
+    ComposerHostedMetadataInvalidationEvent event = captor.getValue();
+
+    assertThat(event.getProject(), is(PROJECT));
+    assertThat(event.getVendor(), is(VENDOR));
+    assertThat(event.getRepositoryName(), is(REPOSITORY_NAME));
+  }
+
+  @Test
+  public void testAssetUpdatedEventWithDifferentRepository() {
+    when(assetUpdatedEvent.getRepositoryName()).thenReturn("other-repository");
+
+    underTest.on(assetUpdatedEvent);
+
+    verify(eventManager, never()).post(any(ComposerHostedMetadataInvalidationEvent.class));
+  }
+
+  @Test
+  public void testAssetUpdatedEventWithDifferentNode() {
+    when(assetUpdatedEvent.isLocal()).thenReturn(false);
+
+    underTest.on(assetUpdatedEvent);
+
+    verify(eventManager, never()).post(any(ComposerHostedMetadataInvalidationEvent.class));
+  }
+
+  @Test
+  public void testAssetUpdatedEventWithNonZipballAsset() {
+    when(formatAttributes.get(P_ASSET_KIND, String.class)).thenReturn(PACKAGES.name());
+
+    underTest.on(assetUpdatedEvent);
+
+    verify(eventManager, never()).post(any(ComposerHostedMetadataInvalidationEvent.class));
+  }
+
+  @Test
+  public void testAssetUpdatedEvent() {
+    underTest.on(assetUpdatedEvent);
+
+    ArgumentCaptor<ComposerHostedMetadataInvalidationEvent> captor = ArgumentCaptor
+        .forClass(ComposerHostedMetadataInvalidationEvent.class);
+
+    verify(eventManager).post(captor.capture());
+
+    ComposerHostedMetadataInvalidationEvent event = captor.getValue();
+
+    assertThat(event.getProject(), is(PROJECT));
+    assertThat(event.getVendor(), is(VENDOR));
+    assertThat(event.getRepositoryName(), is(REPOSITORY_NAME));
+  }
+
+  @Test
+  public void testAssetCreatedEventWithDifferentRepository() {
+    when(assetCreatedEvent.getRepositoryName()).thenReturn("other-repository");
+
+    underTest.on(assetCreatedEvent);
+
+    verify(eventManager, never()).post(any(ComposerHostedMetadataInvalidationEvent.class));
+  }
+
+  @Test
+  public void testAssetCreatedEventWithDifferentNode() {
+    when(assetCreatedEvent.isLocal()).thenReturn(false);
+
+    underTest.on(assetCreatedEvent);
+
+    verify(eventManager, never()).post(any(ComposerHostedMetadataInvalidationEvent.class));
+  }
+
+  @Test
+  public void testAssetCreatedEventWithNonZipballAsset() {
+    when(formatAttributes.get(P_ASSET_KIND, String.class)).thenReturn(PACKAGES.toString());
+
+    underTest.on(assetCreatedEvent);
+
+    verify(eventManager, never()).post(any(ComposerHostedMetadataInvalidationEvent.class));
+  }
+
+  @Test
+  public void testAssetCreatedEvent() {
+    underTest.on(assetCreatedEvent);
+
+    ArgumentCaptor<ComposerHostedMetadataInvalidationEvent> captor = ArgumentCaptor
+        .forClass(ComposerHostedMetadataInvalidationEvent.class);
+
+    verify(eventManager).post(captor.capture());
+
+    ComposerHostedMetadataInvalidationEvent event = captor.getValue();
+
+    assertThat(event.getProject(), is(PROJECT));
+    assertThat(event.getVendor(), is(VENDOR));
+    assertThat(event.getRepositoryName(), is(REPOSITORY_NAME));
+  }
+
+  @Test
+  public void testComposerHostedMetadataInvalidationEventWithDifferentRepository() throws Exception {
+    when(composerHostedMetadataInvalidationEvent.getRepositoryName()).thenReturn("other-repository");
+
+    underTest.on(composerHostedMetadataInvalidationEvent);
+
+    verify(hostedFacet, never()).rebuildProviderJson(any(String.class), any(String.class));
+  }
+
+  @Test
+  public void testComposerHostedMetadataInvalidationEvent() throws Exception {
+    underTest.on(composerHostedMetadataInvalidationEvent);
+
+    verify(hostedFacet).rebuildProviderJson(VENDOR, PROJECT);
+  }
+}

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandlerTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandlerTest.java
@@ -83,6 +83,5 @@ public class ComposerHostedUploadHandlerTest
     assertThat(response.getPayload(), is(nullValue()));
 
     verify(composerHostedFacet).upload("testvendor", "testproject", "testversion", payload);
-    verify(composerHostedFacet).rebuildProviderJson("testvendor", "testproject");
   }
 }

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandlerTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandlerTest.java
@@ -83,5 +83,6 @@ public class ComposerHostedUploadHandlerTest
     assertThat(response.getPayload(), is(nullValue()));
 
     verify(composerHostedFacet).upload("testvendor", "testproject", "testversion", payload);
+    verify(composerHostedFacet).rebuildProviderJson("testvendor", "testproject");
   }
 }

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandlerTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedUploadHandlerTest.java
@@ -82,7 +82,6 @@ public class ComposerHostedUploadHandlerTest
     assertThat(response.getStatus().getCode(), is(200));
     assertThat(response.getPayload(), is(nullValue()));
 
-    verify(composerHostedFacet)
-        .upload("testvendor/testproject/testversion/testvendor-testproject-testversion.zip", payload);
+    verify(composerHostedFacet).upload("testvendor", "testproject", "testversion", payload);
   }
 }

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonExtractorTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonExtractorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.blobstore.api.Blob;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.CharStreams;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class ComposerJsonExtractorTest
+    extends TestSupport
+{
+  @Mock
+  private Blob blob;
+
+  private ComposerJsonExtractor underTest;
+
+  @Before
+  public void setUp() {
+    underTest = new ComposerJsonExtractor();
+  }
+
+  @Test
+  public void extractInfoFromZipballWithJson() throws Exception {
+    String expected;
+    try (InputStream in = getClass().getResourceAsStream("extractInfoFromZipballWithJson.composer.json")) {
+      expected = CharStreams.toString(new InputStreamReader(in, StandardCharsets.UTF_8));
+    }
+    String actual;
+    try (InputStream in = getClass().getResourceAsStream("extractInfoFromZipballWithJson.zip")) {
+      when(blob.getInputStream()).thenReturn(in);
+      actual = new ObjectMapper().writeValueAsString(underTest.extractFromZip(blob));
+    }
+    assertEquals(expected, actual, true);
+  }
+
+  @Test
+  public void extractInfoFromZipballWithoutJson() throws Exception {
+    Map<String, Object> results;
+    try (InputStream in = getClass().getResourceAsStream("extractInfoFromZipballWithoutJson.zip")) {
+      when(blob.getInputStream()).thenReturn(in);
+      results = underTest.extractFromZip(blob);
+    }
+    assertThat(results.isEmpty(), is(true));
+  }
+}

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
@@ -16,13 +16,19 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Collections;
 
 import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.blobstore.api.Blob;
+import org.sonatype.nexus.blobstore.api.BlobRef;
 import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.StorageTx;
 import org.sonatype.nexus.repository.view.Content;
 import org.sonatype.nexus.repository.view.Payload;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -31,6 +37,7 @@ import org.mockito.Mock;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -57,6 +64,48 @@ public class ComposerJsonProcessorTest
   @Mock
   private Component component4;
 
+  @Mock
+  private Asset asset1;
+
+  @Mock
+  private Asset asset2;
+
+  @Mock
+  private Asset asset3;
+
+  @Mock
+  private Asset asset4;
+
+  @Mock
+  private BlobRef blobRef1;
+
+  @Mock
+  private BlobRef blobRef2;
+
+  @Mock
+  private BlobRef blobRef3;
+
+  @Mock
+  private BlobRef blobRef4;
+
+  @Mock
+  private Blob blob1;
+
+  @Mock
+  private Blob blob2;
+
+  @Mock
+  private Blob blob3;
+
+  @Mock
+  private Blob blob4;
+
+  @Mock
+  private StorageTx storageTx;
+
+  @Mock
+  private ComposerJsonExtractor composerJsonExtractor;
+
   @Test
   public void generatePackagesFromList() throws Exception {
     String listJson = readStreamToString(getClass().getResourceAsStream("generatePackagesFromList.list.json"));
@@ -65,7 +114,7 @@ public class ComposerJsonProcessorTest
     when(repository.getUrl()).thenReturn("http://nexus.repo/base/repo");
     when(payload.openInputStream()).thenReturn(new ByteArrayInputStream(listJson.getBytes(UTF_8)));
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor();
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
     Content output = underTest.generatePackagesFromList(repository, payload);
 
     assertEquals(packagesJson, readStreamToString(output.openInputStream()), true);
@@ -89,7 +138,7 @@ public class ComposerJsonProcessorTest
     when(component3.name()).thenReturn("project1");
     when(component3.version()).thenReturn("version2");
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor();
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
     Content output = underTest.generatePackagesFromComponents(repository, asList(component1, component2, component3));
 
     assertEquals(packagesJson, readStreamToString(output.openInputStream()), true);
@@ -103,7 +152,7 @@ public class ComposerJsonProcessorTest
     when(repository.getUrl()).thenReturn("http://nexus.repo/base/repo");
     when(payload.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson.getBytes(UTF_8)));
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor();
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
     Payload output = underTest.rewriteProviderJson(repository, payload);
 
     assertEquals(outputJson, readStreamToString(output.openInputStream()), true);
@@ -119,24 +168,65 @@ public class ComposerJsonProcessorTest
     when(component1.name()).thenReturn("project1");
     when(component1.version()).thenReturn("1.0.0");
     when(component1.requireLastUpdated()).thenReturn(new DateTime(392056200000L, DateTimeZone.forOffsetHours(-4)));
+    when(storageTx.firstAsset(component1)).thenReturn(asset1);
+    when(asset1.requireBlobRef()).thenReturn(blobRef1);
+    when(storageTx.requireBlob(blobRef1)).thenReturn(blob1);
+    when(composerJsonExtractor.extractFromZip(blob1)).thenReturn(new ImmutableMap.Builder<String, Object>()
+        .put("autoload", singletonMap("psr-4", singletonMap("psr-1-key", "psr-1-value")))
+        .put("require", singletonMap("dependency-1", "version-1"))
+        .put("require-dev", singletonMap("dev-dependency-1", "dev-version-1"))
+        .put("suggest", singletonMap("suggest-1", "description-1"))
+        .put("foo", singletonMap("foo-key", "foo-value"))
+        .build());
 
     when(component2.group()).thenReturn("vendor1");
     when(component2.name()).thenReturn("project1");
     when(component2.version()).thenReturn("2.0.0");
     when(component2.requireLastUpdated()).thenReturn(new DateTime(1210869000000L, DateTimeZone.forOffsetHours(-4)));
+    when(storageTx.firstAsset(component2)).thenReturn(asset2);
+    when(asset2.requireBlobRef()).thenReturn(blobRef2);
+    when(storageTx.requireBlob(blobRef2)).thenReturn(blob2);
+    when(composerJsonExtractor.extractFromZip(blob2)).thenReturn(new ImmutableMap.Builder<String, Object>()
+        .put("autoload", singletonMap("psr-0", singletonMap("psr-2-key", "psr-2-value")))
+        .put("require", singletonMap("dependency-2", "version-2"))
+        .put("require-dev", singletonMap("dev-dependency-2", "dev-version-2"))
+        .put("suggest", singletonMap("suggest-2", "description-2"))
+        .put("foo", singletonMap("foo-key", "foo-value"))
+        .build());
 
     when(component3.group()).thenReturn("vendor2");
     when(component3.name()).thenReturn("project2");
     when(component3.version()).thenReturn("3.0.0");
     when(component3.requireLastUpdated()).thenReturn(new DateTime(300558600000L, DateTimeZone.forOffsetHours(-4)));
+    when(storageTx.firstAsset(component3)).thenReturn(asset3);
+    when(asset3.requireBlobRef()).thenReturn(blobRef3);
+    when(storageTx.requireBlob(blobRef3)).thenReturn(blob3);
+    when(composerJsonExtractor.extractFromZip(blob3)).thenReturn(new ImmutableMap.Builder<String, Object>()
+        .put("autoload", singletonMap("psr-4", singletonMap("psr-3-key", "psr-3-value")))
+        .put("require", singletonMap("dependency-3", "version-3"))
+        .put("require-dev", singletonMap("dev-dependency-3", "dev-version-3"))
+        .put("suggest", singletonMap("suggest-3", "description-3"))
+        .put("foo", singletonMap("foo-key", "foo-value"))
+        .build());
 
     when(component4.group()).thenReturn("vendor2");
     when(component4.name()).thenReturn("project2");
     when(component4.version()).thenReturn("4.0.0");
     when(component4.requireLastUpdated()).thenReturn(new DateTime(1210869000000L, DateTimeZone.forOffsetHours(-4)));
+    when(storageTx.firstAsset(component4)).thenReturn(asset4);
+    when(asset4.requireBlobRef()).thenReturn(blobRef4);
+    when(storageTx.requireBlob(blobRef4)).thenReturn(blob4);
+    when(composerJsonExtractor.extractFromZip(blob4)).thenReturn(new ImmutableMap.Builder<String, Object>()
+        .put("autoload", singletonMap("psr-0", singletonMap("psr-4-key", "psr-4-value")))
+        .put("require", singletonMap("dependency-4", "version-4"))
+        .put("require-dev", singletonMap("dev-dependency-4", "dev-version-4"))
+        .put("suggest", singletonMap("suggest-4", "description-4"))
+        .put("foo", singletonMap("foo-key", "foo-value"))
+        .build());
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor();
-    Content output = underTest.buildProviderJson(repository, asList(component1, component2, component3, component4));
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
+    Content output = underTest
+        .buildProviderJson(repository, storageTx, asList(component1, component2, component3, component4));
 
     assertEquals(outputJson, readStreamToString(output.openInputStream()), true);
   }
@@ -146,7 +236,7 @@ public class ComposerJsonProcessorTest
     String inputJson = readStreamToString(getClass().getResourceAsStream("getDistUrl.json"));
     when(payload.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson.getBytes(UTF_8)));
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor();
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
     String distUrl = underTest.getDistUrl("vendor1", "project1", "2.0.0", payload);
 
     assertThat(distUrl, is("https://git.example.com/zipball/418e708b379598333d0a48954c0fa210437795be"));

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/buildProviderJson.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/buildProviderJson.json
@@ -1,47 +1,103 @@
 {
-  "packages" : {
-    "vendor1/project1" : {
-      "1.0.0" : {
+  "packages": {
+    "vendor1/project1": {
+      "1.0.0": {
         "name": "vendor1/project1",
         "version": "1.0.0",
-        "dist" : {
-          "url" : "http://nexus.repo/base/repo/vendor1/project1/1.0.0/vendor1-project1-1.0.0.zip",
-          "type" : "zip"
+        "dist": {
+          "url": "http://nexus.repo/base/repo/vendor1/project1/1.0.0/vendor1-project1-1.0.0.zip",
+          "type": "zip"
         },
-        "uid" : 1345846687,
-        "time" : "1982-06-04T16:30:00+00:00"
+        "uid": 1345846687,
+        "time": "1982-06-04T16:30:00+00:00",
+        "autoload": {
+          "psr-4": {
+            "psr-1-key": "psr-1-value"
+          }
+        },
+        "require": {
+          "dependency-1": "version-1"
+        },
+        "require-dev": {
+          "dev-dependency-1": "dev-version-1"
+        },
+        "suggest": {
+          "suggest-1": "description-1"
+        }
       },
-      "2.0.0" : {
+      "2.0.0": {
         "name": "vendor1/project1",
         "version": "2.0.0",
-        "dist" : {
-          "url" : "http://nexus.repo/base/repo/vendor1/project1/2.0.0/vendor1-project1-2.0.0.zip",
-          "type" : "zip"
+        "dist": {
+          "url": "http://nexus.repo/base/repo/vendor1/project1/2.0.0/vendor1-project1-2.0.0.zip",
+          "type": "zip"
         },
-        "uid" : 1700253429,
-        "time" : "2008-05-15T16:30:00+00:00"
+        "uid": 1700253429,
+        "time": "2008-05-15T16:30:00+00:00",
+        "autoload": {
+          "psr-0": {
+            "psr-2-key": "psr-2-value"
+          }
+        },
+        "require": {
+          "dependency-2": "version-2"
+        },
+        "require-dev": {
+          "dev-dependency-2": "dev-version-2"
+        },
+        "suggest": {
+          "suggest-2": "description-2"
+        }
       }
     },
-    "vendor2/project2" : {
-      "3.0.0" : {
+    "vendor2/project2": {
+      "3.0.0": {
         "name": "vendor2/project2",
         "version": "3.0.0",
-        "dist" : {
-          "url" : "http://nexus.repo/base/repo/vendor2/project2/3.0.0/vendor2-project2-3.0.0.zip",
-          "type" : "zip"
+        "dist": {
+          "url": "http://nexus.repo/base/repo/vendor2/project2/3.0.0/vendor2-project2-3.0.0.zip",
+          "type": "zip"
         },
-        "uid" : 1398386772,
-        "time" : "1979-07-11T16:30:00+00:00"
+        "uid": 1398386772,
+        "time": "1979-07-11T16:30:00+00:00",
+        "autoload": {
+          "psr-4": {
+            "psr-3-key": "psr-3-value"
+          }
+        },
+        "require": {
+          "dependency-3": "version-3"
+        },
+        "require-dev": {
+          "dev-dependency-3": "dev-version-3"
+        },
+        "suggest": {
+          "suggest-3": "description-3"
+        }
       },
-      "4.0.0" : {
+      "4.0.0": {
         "name": "vendor2/project2",
         "version": "4.0.0",
-        "dist" : {
-          "url" : "http://nexus.repo/base/repo/vendor2/project2/4.0.0/vendor2-project2-4.0.0.zip",
-          "type" : "zip"
+        "dist": {
+          "url": "http://nexus.repo/base/repo/vendor2/project2/4.0.0/vendor2-project2-4.0.0.zip",
+          "type": "zip"
         },
-        "uid" : 237122898,
-        "time" : "2008-05-15T16:30:00+00:00"
+        "uid": 237122898,
+        "time": "2008-05-15T16:30:00+00:00",
+        "autoload": {
+          "psr-0": {
+            "psr-4-key": "psr-4-value"
+          }
+        },
+        "require": {
+          "dependency-4": "version-4"
+        },
+        "require-dev": {
+          "dev-dependency-4": "dev-version-4"
+        },
+        "suggest": {
+          "suggest-4": "description-4"
+        }
       }
     }
   }

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/extractInfoFromZipballWithJson.composer.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/extractInfoFromZipballWithJson.composer.json
@@ -1,0 +1,57 @@
+{
+    "name": "vendor/project",
+	"version" : "1.2.3",
+    "description": "Test description",
+    "keywords": ["keyword1", "keyword2", "keyword3"],
+    "homepage": "http://www.example.com/",
+	"time": "2008-05-15",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Author1",
+            "email": "author1@example.com",
+            "homepage": "http://www.example.com/author1"
+        },
+        {
+            "name": "Author2",
+            "email": "author2@example.com",
+            "homepage": "http://www.example.com/author2"
+        }
+    ],
+    "support": {
+		"email": "email@example.com",
+		"issues": "http://www.example.com/issues",
+		"forum": "http://www.example.com/forum",
+		"wiki": "http://www.example.com/wiki",
+		"issues": "irc://irc.example.com/irc",
+		"source": "http://www.example.com/source",
+		"docs": "http://www.example.com/docs",
+		"rss": "http://www.example.com/rss"
+    },
+    "require": {
+        "php": "^5.3.2 || ^7.0",
+        "symfony/console": "^2.7 || ^3.0 || ^4.0",
+        "symfony/finder": "^2.7 || ^3.0 || ^4.0",
+        "symfony/process": "^2.7 || ^3.0 || ^4.0",
+        "symfony/filesystem": "^2.7 || ^3.0 || ^4.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8.35 || ^5.7",
+        "phpunit/phpunit-mock-objects": "^2.3 || ^3.0"
+    },
+    "config": {
+        "platform": {
+            "php": "5.3.9"
+        }
+    },
+    "bin": ["bin/example"],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.7-dev"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}


### PR DESCRIPTION
Fixes #17 by rebuilding the `provider.json` for a particular vendor and project whenever an asset associated with that vendor/project pair is created, updated, or deleted. 

Additional fields for `autoload`, `require`, `require-dev`, and `suggest` are included in the generated `provider.json` in order to correctly support autoload and dependency resolution for hosted artifacts.

Much of this implementation is essentially a stripped-down form of what we do for our Yum implementation, so hopefully keeping it running or applying the same shared lessons in the future will be made easier by this design choice. There are opportunities for improvement here as well.

Note that if this PR goes in before the outstanding group PR, then we'll need to update group merge. If the group PR goes in before this, then we should also update this to correctly account for the new fields on group merge.