### PR TITLE
Cache maven dependencies to speed up build, prevent timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: java
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 * [Developing](#developing)
    * [Requirements](#requirements)
    * [Building](#building)
+   * [Travis CI](#travis-ci)
 * [Using Composer with Nexus Repository Manger 3](#using-composer-with-nexus-repository-manager-3)
 * [Installing the plugin](#installing-the-plugin)
    * [Temporary Install](#temporary-install)
@@ -45,6 +46,11 @@ To build the project and generate the bundle use Maven
     mvn clean package
 
 If everything checks out, the bundle for Composer should be available in the `target` folder
+
+### Travis CI
+
+This project is built automatically with Travis CI, and you should be able to see build results on your commits, as well
+as directly on [Travis CI](https://travis-ci.org/sonatype-nexus-community/nexus-repository-composer/).
 
 #### Build with Docker
 


### PR DESCRIPTION
This should in theory cache Maven dependencies, speeding up the builds quite a bit. 

This pull request makes the following changes:
* Small change to .travis.yml to cache the m2 directory