### PR TITLE
Add type to provider JSON

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,3 +25,4 @@ External contributors:
 
 * [@TheBay0r](https://github.com/TheBay0r) (Stefan Schacherl)
 * [@Elendev](https://github.com/Elendev) (Jonas Renaudot)
+* [@stefaanneyts](https://github.com/stefaanneyts) (Stefaan Neyts)

--- a/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessor.java
+++ b/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessor.java
@@ -386,6 +386,9 @@ public class ComposerJsonProcessor
     if (versionInfo.containsKey(SUPPORT_KEY)) {
       newPackageInfo.put(SUPPORT_KEY, versionInfo.get(SUPPORT_KEY));
     }
+    if (versionInfo.containsKey(TYPE_KEY)) {
+      newPackageInfo.put(TYPE_KEY, versionInfo.get(TYPE_KEY));
+    }
 
     return newPackageInfo;
   }

--- a/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
@@ -215,6 +215,7 @@ public class ComposerJsonProcessorTest
         .put("target-dir", "target-dir-1")
         .put("scripts", singletonMap("scripts-1", asList("script-1")))
         .put("support", singletonMap("support-1", "support-1-value"))
+        .put("type", "type-1-value")
         .put("foo", singletonMap("foo-key", "foo-value"))
         .build());
 
@@ -245,6 +246,7 @@ public class ComposerJsonProcessorTest
         .put("target-dir", "target-dir-2")
         .put("scripts", singletonMap("scripts-2", asList("script-2")))
         .put("support", singletonMap("support-2", "support-2-value"))
+        .put("type", "type-2-value")
         .put("foo", singletonMap("foo-key", "foo-value"))
         .build());
 
@@ -275,6 +277,7 @@ public class ComposerJsonProcessorTest
         .put("target-dir", "target-dir-3")
         .put("scripts", singletonMap("scripts-3", asList("script-3")))
         .put("support", singletonMap("support-3", "support-3-value"))
+        .put("type", "type-3-value")
         .put("foo", singletonMap("foo-key", "foo-value"))
         .build());
 
@@ -305,6 +308,7 @@ public class ComposerJsonProcessorTest
         .put("target-dir", "target-dir-4")
         .put("scripts", singletonMap("scripts-4", asList("script-4")))
         .put("support", singletonMap("support-4", "support-4-value"))
+        .put("type", "type-4-value")
         .put("foo", singletonMap("foo-key", "foo-value"))
         .build());
 

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/buildProviderJson.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/buildProviderJson.json
@@ -69,7 +69,8 @@
         },
         "support" : {
           "support-1" : "support-1-value"
-        }
+        },
+        "type" : "type-1-value"
       },
       "2.0.0": {
         "name": "vendor1/project1",
@@ -139,7 +140,8 @@
         },
         "support" : {
           "support-2" : "support-2-value"
-        }
+        },
+        "type" : "type-2-value"
       }
     },
     "vendor2/project2": {
@@ -211,7 +213,8 @@
         },
         "support" : {
           "support-3" : "support-3-value"
-        }
+        },
+        "type" : "type-3-value"
       },
       "4.0.0": {
         "name": "vendor2/project2",
@@ -281,7 +284,8 @@
         },
         "support" : {
           "support-4" : "support-4-value"
-        }
+        },
+        "type" : "type-4-value"
       }
     }
   }

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergeProviderJson.input1.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergeProviderJson.input1.json
@@ -69,7 +69,8 @@
           "scripts-1": [
             "script-1"
           ]
-        }
+        },
+        "type" : "type-1-value"
       }
     },
     "vendor3/project3": {
@@ -110,7 +111,8 @@
         },
         "suggest": {
           "suggest-2": "description-2"
-        }
+        },
+        "type" : "type-2-value"
       }
     }
   }

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergeProviderJson.input2.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergeProviderJson.input2.json
@@ -25,7 +25,8 @@
         },
         "suggest": {
           "suggest-3": "description-3"
-        }
+        },
+        "type": "type-1-value"
       },
       "2.0.0" : {
         "name": "vendor1/project1",
@@ -51,7 +52,8 @@
         },
         "suggest": {
           "suggest-4": "description-4"
-        }
+        },
+        "type": "type-2-value"
       }
     },
     "vendor2/project2" : {
@@ -79,7 +81,8 @@
         },
         "suggest": {
           "suggest-5": "description-5"
-        }
+        },
+        "type": "type-3-value"
       },
       "4.0.0" : {
         "name": "vendor2/project2",
@@ -105,7 +108,8 @@
         },
         "suggest": {
           "suggest-6": "description-6"
-        }
+        },
+        "type": "type-4-value"
       }
     }
   }

--- a/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergeProviderJson.output.json
+++ b/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergeProviderJson.output.json
@@ -68,7 +68,8 @@
           "scripts-1": [
             "script-1"
           ]
-        }
+        },
+        "type" : "type-1-value"
       },
       "2.0.0" : {
         "name": "vendor1/project1",
@@ -94,7 +95,8 @@
         },
         "suggest": {
           "suggest-4": "description-4"
-        }
+        },
+        "type" : "type-2-value"
       }
     },
     "vendor2/project2" : {
@@ -122,7 +124,8 @@
         },
         "suggest": {
           "suggest-5": "description-5"
-        }
+        },
+        "type" : "type-3-value"
       },
       "4.0.0" : {
         "name": "vendor2/project2",
@@ -148,7 +151,8 @@
         },
         "suggest": {
           "suggest-6": "description-6"
-        }
+        },
+        "type" : "type-4-value"
       }
     },
     "vendor3/project3" : {
@@ -188,7 +192,8 @@
         },
         "suggest": {
           "suggest-2": "description-2"
-        }
+        },
+        "type" : "type-2-value"
       }
     }
   }


### PR DESCRIPTION
The provider JSON does not include type at the package level. Compose will fallback to the default type which is "library". Packagist.org has types like "project", "application", "composer-plugin", ... This fix will output the correct type in the provider JSON.

This pull request makes the following changes:
* Add type to provider JSON.
