### PR TITLE
Update docs to correct json example and add commands that may be easi…

### DIFF
--- a/docs/COMPOSER_USER_DOCUMENTATION.md
+++ b/docs/COMPOSER_USER_DOCUMENTATION.md
@@ -58,21 +58,30 @@ Minimal configuration steps are:
 
 The least-invasive way of configuring the Composer client to communicate with Nexus is to update the `repositories`
 section in the `composer.json` for your particular project. We also recommend turning off `packagist.org` access so
-that all requests are directed to your Nexus repository manager.
+that all requests are directed to your Nexus repository manager. The following settings assumes the URL proviced by Nexus is `https://localhost:8081/repository/packagist/`. If you named your Composer repository another name substitute the URL provided to you by Nexus. Note that the trailing slash at the end of the URL is required by Nexus to operate correctly.
+
+Composer supplies commands to alter your `composer.json`. To add your Nexus repo issue the following command in your project
+`composer config repo.foo '{"type": "composer", "url": "https://localhost:8081/repository/packagist/"}'` where `foo` is just an indexed name. Numbers may also be used for the index.
+
+If you want do disable Packagist for your project issue this command `composer config repo.packagist false`.
+
+If you want to disable Packagist globally (say you are running in a Docker container) issue this command `composer config -g repo.packagist false`.
+
+If you would like to edit the composer.json manually the entry would look as follows:
 
 ```
 {
   "repositories": [
     {
       "type": "composer",
-      "url": "http://localhost:8081/repository/packagist"
+      "url": "https://localhost:8081/repository/packagist/"
     },
-    {
-      "packagist.org": false
-    }
+    "packagist.org": false
   ]
 }
 ```
+
+By default, Composer will only allow HTTPS URLs. To allow non-SSL URLs you will have to set [secure-http](https://getcomposer.org/doc/06-config.md#secure-http) to `false`.
 
 ### Browsing Composer Repository Packages
 

--- a/docs/COMPOSER_USER_DOCUMENTATION.md
+++ b/docs/COMPOSER_USER_DOCUMENTATION.md
@@ -57,10 +57,10 @@ Minimal configuration steps are:
 ### Configuring Composer 
 
 The least-invasive way of configuring the Composer client to communicate with Nexus is to update the `repositories`
-section in the `composer.json` for your particular project. We also recommend turning off `packagist.org` access so
+section in the `composer.json` for your particular project. We also recommend [disabling](https://getcomposer.org/doc/05-repositories.md#disabling-packagist-org) `packagist.org` access so
 that all requests are directed to your Nexus repository manager. The following settings assumes the URL proviced by Nexus is `https://localhost:8081/repository/packagist/`. If you named your Composer repository another name substitute the URL provided to you by Nexus. Note that the trailing slash at the end of the URL is required by Nexus to operate correctly.
 
-Composer supplies commands to alter your `composer.json`. To add your Nexus repo issue the following command in your project
+Composer [supplies commands](https://getcomposer.org/doc/03-cli.md#modifying-repositories) to alter your `composer.json`. To add your Nexus repo issue the following command in your project
 `composer config repo.foo '{"type": "composer", "url": "https://localhost:8081/repository/packagist/"}'` where `foo` is just an indexed name. Numbers may also be used for the index.
 
 If you want do disable Packagist for your project issue this command `composer config repo.packagist false`.

--- a/docs/COMPOSER_USER_DOCUMENTATION.md
+++ b/docs/COMPOSER_USER_DOCUMENTATION.md
@@ -61,7 +61,7 @@ section in the `composer.json` for your particular project. We also recommend [d
 that all requests are directed to your Nexus repository manager. The following settings assumes the URL proviced by Nexus is `https://localhost:8081/repository/packagist/`. If you named your Composer repository another name substitute the URL provided to you by Nexus. Note that the trailing slash at the end of the URL is required by Nexus to operate correctly.
 
 Composer [supplies commands](https://getcomposer.org/doc/03-cli.md#modifying-repositories) to alter your `composer.json`. To add your Nexus repo issue the following command in your project
-`composer config repo.foo '{"type": "composer", "url": "https://localhost:8081/repository/packagist/"}'` where `foo` is just an indexed name. Numbers may also be used for the index.
+`composer config repo.foo '{"type": "composer", "url": "https://localhost:8081/repository/packagist/"}'` or `composer config repo.foo composer https://localhost:8081/repository/packagist/` where `foo` is just an indexed name. Numbers may also be used for the index.
 
 If you want do disable Packagist for your project issue this command `composer config repo.packagist false`.
 


### PR DESCRIPTION
The composer documentation had an error in the example JSON and there are other ways to edit the composer.json that may be easier for people to use using `composer config` commands.

This pull request makes the following changes:
* Update Composer usage documentation
