### PR TITLE
Permanent Install Documentation Update

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@ Sonatype internal people, in alphabetical order by username:
 * [@doddi](https://github.com/doddi/) (Mark Dodgson)
 * [@fjmilens3](https://github.com/fjmilens3/) (Frederick Milens)
 * [@jlstephens89](https://github.com/jlstephens89/) (Joseph Stephens)
+* [@joedragons](https://github.com/joedragons/) (Joe Tom)
 
 External contributors:
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ You should see the new repository types (e.g. `composer (hosted, proxy, group)`)
 Installations done via the Karaf console will be wiped out with every restart of Nexus Repository. This is a
 good installation path if you are just testing or doing development on the plugin.
 
-* Enable Nexus console: edit `<nexus_dir>/bin/nexus.vmoptions` and change `karaf.startLocalConsole`  to `true`.
+* Enable the NXRM console: edit `<nexus_dir>/bin/nexus.vmoptions` and change `karaf.startLocalConsole`  to `true`.
 
   More details here: [Bundle Development](https://help.sonatype.com/display/NXRM3/Bundle+Development+Overview)
 
-* Run Nexus' console:
+* Run NXRM's console:
   ```
   # sudo su - nexus
   $ cd <nexus_dir>/bin
@@ -135,12 +135,12 @@ is running. You will still need to start the bundle using the karaf commands men
 If you are trying to use the Composer plugin permanently, it likely makes more sense to do the following:
 
 * Copy the bundle into `<nexus_dir>/system/org/sonatype/nexus/plugins/nexus-repository-composer/0.0.2/nexus-repository-composer-0.0.2.jar`
-* Make the following additions marked with + to `<nexus_dir>/system/org/sonatype/nexus/assemblies/nexus-core-feature/3.x.y/nexus-core-feature-3.x.y-features.xml`
+* Make the following additions marked with + to `<nexus_dir>/system/org/sonatype/nexus/assemblies/nexus-cma-feature/3.x.y/nexus-cma-feature-3.x.y-features.xml`
 
    ```
-         <feature prerequisite="false" dependency="false">nexus-repository-rubygems</feature>
-   +     <feature prerequisite="false" dependency="false">nexus-repository-composer</feature>
-         <feature prerequisite="false" dependency="false">nexus-repository-gitlfs</feature>
+         <feature version="3.x.y.xy">nexus-repository-conda</feature>
+   +     <feature version="0.0.2">nexus-repository-composer</feature>
+         <feature version="3.x.y.xy">nexus-repository-golang</feature>
      </feature>
    ```
    And
@@ -152,6 +152,8 @@ If you are trying to use the Composer plugin permanently, it likely makes more s
     </features>
    ```
 This will cause the plugin to be loaded and started with each startup of Nexus Repository.
+
+NOTE: The file location changed in version 3.21. For older versions, add to this file: `<nexus_dir>/system/org/sonatype/nexus/assemblies/nexus-core-feature/3.x.y/nexus-core-feature-3.x.y-features.xml`
 
 ## The Fine Print
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ good installation path if you are just testing or doing development on the plugi
   # sudo su - nexus
   $ cd <nexus_dir>/bin
   $ ./nexus run
-  > bundle:install file:///tmp/nexus-repository-composer-0.0.2.jar
+  > bundle:install file:///tmp/nexus-repository-composer-0.0.5.jar
   > bundle:list
   ```
   (look for org.sonatype.nexus.plugins:nexus-repository-composer ID, should be the last one)
@@ -124,7 +124,7 @@ good installation path if you are just testing or doing development on the plugi
 
 For more permanent installs of the nexus-repository-composer plugin, follow these instructions:
 
-* Copy the bundle (nexus-repository-composer-0.0.2.jar) into <nexus_dir>/deploy
+* Copy the bundle (nexus-repository-composer-0.0.5.jar) into <nexus_dir>/deploy
 
 This will cause the plugin to be loaded with each restart of Nexus Repository. As well, this folder is monitored
 by Nexus Repository and the plugin should load within 60 seconds of being copied there if Nexus Repository
@@ -134,20 +134,20 @@ is running. You will still need to start the bundle using the karaf commands men
 
 If you are trying to use the Composer plugin permanently, it likely makes more sense to do the following:
 
-* Copy the bundle into `<nexus_dir>/system/org/sonatype/nexus/plugins/nexus-repository-composer/0.0.2/nexus-repository-composer-0.0.2.jar`
+* Copy the bundle into `<nexus_dir>/system/org/sonatype/nexus/plugins/nexus-repository-composer/0.0.5/nexus-repository-composer-0.0.5.jar`
 * Make the following additions marked with + to `<nexus_dir>/system/org/sonatype/nexus/assemblies/nexus-cma-feature/3.x.y/nexus-cma-feature-3.x.y-features.xml`
 
    ```
          <feature version="3.x.y.xy">nexus-repository-conda</feature>
-   +     <feature version="0.0.2">nexus-repository-composer</feature>
+   +     <feature version="0.0.5">nexus-repository-composer</feature>
          <feature version="3.x.y.xy">nexus-repository-golang</feature>
      </feature>
    ```
    And
    ```
-   + <feature name="nexus-repository-composer" description="org.sonatype.nexus.plugins:nexus-repository-composer" version="0.0.2">
+   + <feature name="nexus-repository-composer" description="org.sonatype.nexus.plugins:nexus-repository-composer" version="0.0.5">
    +     <details>org.sonatype.nexus.plugins:nexus-repository-composer</details>
-   +     <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-composer/0.0.2</bundle>
+   +     <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-composer/0.0.5</bundle>
    + </feature>
     </features>
    ```


### PR DESCRIPTION
It was noted on gitter that the install section no longer exists in the given location. I have updated the file location and examples.
Also boyscouted some Nexus to NXRM.