### PR TITLE
NEXUS-25906 Extra slash in the URI for asset in community formats

### DIFF
--- a/nexus-repository-composer/src/main/resources/static/rapture/NX/composer/util/ComposerRepositoryUrls.js
+++ b/nexus-repository-composer/src/main/resources/static/rapture/NX/composer/util/ComposerRepositoryUrls.js
@@ -19,8 +19,10 @@ Ext.define('NX.composer.util.ComposerRepositoryUrls', {
     'NX.util.Url'
   ]
 }, function(self) {
-  NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('composer', function(assetModel) {
+  NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('composer', function(me, assetModel) {
     var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
-    return NX.util.Url.asLink(NX.util.Url.baseUrl + '/repository/' + repositoryName + '/' + assetName, assetName);
+    return NX.util.Url.asLink(
+        NX.util.Url.baseUrl + '/repository/' + encodeURIComponent(repositoryName) + '/' + encodeURI(assetName),
+        assetName);
   });
 });


### PR DESCRIPTION
Fix the code inconsistency with NEXUS internal

This pull request makes the following changes:
* fix parameter of`addRepositoryUrlStrategy` JS method
