### PR TITLE
Update composer-push repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ Looking to contribute to our code but need some help? There's a few ways to get 
 * Check out the [Nexus Repository User List](https://groups.google.com/a/glists.sonatype.com/forum/?hl=en#!forum/nexus-users)
 
 ## Composer Plugin
-The composer plugin `elendev/nexus-composer-push` (https://github.com/Elendev/nexus-composer-push) provide a composer command to push to a Nexus Repository using this plugin.
+The composer plugin `elendev/composer-push` (https://github.com/Elendev/composer-push) provide a composer command to push to a Nexus Repository using this plugin.


### PR DESCRIPTION
(brief, plain english overview of your changes here)
The plugin has been renamed to `elendev/composer-push`.

This pull request makes the following changes:
* Link to `elendev/composer-push` instead of deprecated `elendev/nexus-composer-push` in the readme.
