### PR TITLE
Implement cleanup policy

### DIFF
--- a/nexus-repository-composer/pom.xml
+++ b/nexus-repository-composer/pom.xml
@@ -33,6 +33,11 @@
     </dependency>
     <dependency>
       <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-cleanup</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-rapture</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/cleanup/ComposerCleanupPolicyConfiguration.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/cleanup/ComposerCleanupPolicyConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.repository.composer.internal.cleanup;
+
+import java.util.Map;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.cleanup.config.CleanupPolicyConfiguration;
+import org.sonatype.repository.composer.internal.ComposerFormat;
+
+import com.google.common.collect.ImmutableMap;
+
+import static org.sonatype.nexus.repository.search.DefaultComponentMetadataProducer.IS_PRERELEASE_KEY;
+import static org.sonatype.nexus.repository.search.DefaultComponentMetadataProducer.LAST_BLOB_UPDATED_KEY;
+import static org.sonatype.nexus.repository.search.DefaultComponentMetadataProducer.LAST_DOWNLOADED_KEY;
+import static org.sonatype.nexus.repository.search.DefaultComponentMetadataProducer.REGEX_KEY;
+
+/**
+ * @since 3.next
+ */
+@Named(ComposerFormat.NAME)
+@Singleton
+public class ComposerCleanupPolicyConfiguration
+    implements CleanupPolicyConfiguration
+{
+  @Override
+  public Map<String, Boolean> getConfiguration() {
+    return ImmutableMap.of(LAST_BLOB_UPDATED_KEY, true,
+        LAST_DOWNLOADED_KEY, true,
+        IS_PRERELEASE_KEY, false,
+        REGEX_KEY, true);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/cleanup/ComposerCleanupPolicyConfiguration.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/cleanup/ComposerCleanupPolicyConfiguration.java
@@ -10,7 +10,7 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package org.sonatype.repository.composer.internal.cleanup;
+package org.sonatype.nexus.repository.composer.internal.cleanup;
 
 import java.util.Map;
 
@@ -18,7 +18,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.sonatype.nexus.cleanup.config.CleanupPolicyConfiguration;
-import org.sonatype.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/nexus-repository-composer/src/main/resources/static/rapture/NX/composer/view/repository/recipe/ComposerHosted.js
+++ b/nexus-repository-composer/src/main/resources/static/rapture/NX/composer/view/repository/recipe/ComposerHosted.js
@@ -20,7 +20,8 @@ Ext.define('NX.composer.view.repository.recipe.ComposerHosted', {
   alias: 'widget.nx-coreui-repository-composer-hosted',
   requires: [
     'NX.coreui.view.repository.facet.StorageFacet',
-    'NX.coreui.view.repository.facet.StorageFacetHosted'
+    'NX.coreui.view.repository.facet.StorageFacetHosted',
+    'NX.coreui.view.repository.facet.CleanupPolicyFacet'
   ],
 
   /**
@@ -31,7 +32,8 @@ Ext.define('NX.composer.view.repository.recipe.ComposerHosted', {
 
     me.items = [
       {xtype: 'nx-coreui-repository-storage-facet'},
-      {xtype: 'nx-coreui-repository-storage-hosted-facet', writePolicy: 'ALLOW'}
+      {xtype: 'nx-coreui-repository-storage-hosted-facet', writePolicy: 'ALLOW'},
+      {xtype: 'nx-coreui-repository-cleanup-policy-facet'}
     ];
 
     me.callParent();

--- a/nexus-repository-composer/src/main/resources/static/rapture/NX/composer/view/repository/recipe/ComposerProxy.js
+++ b/nexus-repository-composer/src/main/resources/static/rapture/NX/composer/view/repository/recipe/ComposerProxy.js
@@ -22,7 +22,8 @@ Ext.define('NX.composer.view.repository.recipe.ComposerProxy', {
     'NX.coreui.view.repository.facet.ProxyFacet',
     'NX.coreui.view.repository.facet.StorageFacet',
     'NX.coreui.view.repository.facet.HttpClientFacet',
-    'NX.coreui.view.repository.facet.NegativeCacheFacet'
+    'NX.coreui.view.repository.facet.NegativeCacheFacet',
+    'NX.coreui.view.repository.facet.CleanupPolicyFacet'
   ],
 
   /**
@@ -35,7 +36,8 @@ Ext.define('NX.composer.view.repository.recipe.ComposerProxy', {
       {xtype: 'nx-coreui-repository-proxy-facet'},
       {xtype: 'nx-coreui-repository-storage-facet'},
       {xtype: 'nx-coreui-repository-negativecache-facet'},
-      {xtype: 'nx-coreui-repository-httpclient-facet'}
+      {xtype: 'nx-coreui-repository-httpclient-facet'},
+      {xtype: 'nx-coreui-repository-cleanup-policy-facet'}
     ];
 
     me.callParent();


### PR DESCRIPTION
This PR addresses https://github.com/sonatype-nexus-community/nexus-repository-composer/issues/63 and implements the needed changes to assign cleanup policies to Composer repositories. This greatly helps to maintain your Nexus instance to not waste disk space for old/unused artifacts.

I used the referenced PR from the issue pointing to the Conan repo plugin and how they implemented there.

![image](https://user-images.githubusercontent.com/1675399/145040518-1223f3f1-bc1c-4e5b-b9bd-6276a5d836e8.png)

It relates to the following issue #s:
* Fixes #63 

I tested it successfully on our own Nexus instance and it cleaned up the artifact as expected.