### PR TITLE
Add basic support for composer v2

### DIFF
--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/AssetKind.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/AssetKind.java
@@ -25,7 +25,8 @@ public enum AssetKind
   ZIPBALL(CONTENT),
   PACKAGES(METADATA),
   LIST(METADATA),
-  PROVIDER(METADATA);
+  PROVIDER(METADATA),
+  PACKAGE(METADATA);
 
   private final CacheType cacheType;
 

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImpl.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImpl.java
@@ -111,6 +111,8 @@ public class ComposerContentFacetImpl
           return doPutContent(path, tempBlob, payload, assetKind, null, null, null);
         case PACKAGES:
           return doPutMetadata(path, tempBlob, payload, assetKind);
+        case PACKAGE:
+          return doPutMetadata(path, tempBlob, payload, assetKind);
         case LIST:
           return doPutMetadata(path, tempBlob, payload, assetKind);
         case PROVIDER:

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerGroupPackageJsonHandler.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerGroupPackageJsonHandler.java
@@ -12,34 +12,36 @@
  */
 package org.sonatype.nexus.repository.composer.internal;
 
-import java.io.IOException;
-
-import javax.annotation.Nullable;
-
-import org.sonatype.nexus.repository.Facet;
+import org.joda.time.DateTime;
+import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.view.Content;
 import org.sonatype.nexus.repository.view.Payload;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
- * Interface defining the features supported by Composer repository hosted facets.
+ * Handler for merging package JSON files together.
  */
-@Facet.Exposed
-public interface ComposerHostedFacet
-    extends Facet
+@Named
+@Singleton
+public class ComposerGroupPackageJsonHandler
+    extends ComposerGroupMergingHandler
 {
-  void upload(String vendor, String project, String version, String sourceType, String sourceUrl,
-              String sourceReference, Payload payload) throws IOException;
+  private final ComposerJsonProcessor composerJsonProcessor;
 
-  Content getPackagesJson() throws IOException;
+  @Inject
+  public ComposerGroupPackageJsonHandler(final ComposerJsonProcessor composerJsonProcessor) {
+    this.composerJsonProcessor = checkNotNull(composerJsonProcessor);
+  }
 
-  Content getProviderJson(String vendor, String project) throws IOException;
-
-  Content getPackageJson(String vendor, String project) throws IOException;
-
-  void rebuildPackageJson(String vendor, String project) throws IOException;
-
-  void rebuildProviderJson(String vendor, String project) throws IOException;
-
-  @Nullable
-  Content getZipball(String path) throws IOException;
+  @Override
+  protected Content merge(final Repository repository, final List<Payload> payloads) throws IOException {
+    return composerJsonProcessor.mergePackageJson(repository, payloads, DateTime.now());
+  }
 }

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerGroupRecipe.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerGroupRecipe.groovy
@@ -52,6 +52,9 @@ class ComposerGroupRecipe
   ComposerGroupProviderJsonHandler providerJsonHandler
 
   @Inject
+  ComposerGroupPackageJsonHandler packageJsonHandler
+
+  @Inject
   ComposerGroupRecipe(@Named(GroupType.NAME) final Type type, @Named(ComposerFormat.NAME) final Format format) {
     super(type, format)
   }
@@ -88,6 +91,15 @@ class ComposerGroupRecipe
         .handler(handlerContributor)
         .handler(providerJsonHandler)
         .create())
+
+    builder.route(packageMatcher()
+            .handler(timingHandler)
+            .handler(assetKindHandler.rcurry(AssetKind.PACKAGE))
+            .handler(securityHandler)
+            .handler(exceptionHandler)
+            .handler(handlerContributor)
+            .handler(packageJsonHandler)
+            .create())
 
     builder.route(zipballMatcher()
         .handler(timingHandler)

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedDownloadHandler.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedDownloadHandler.java
@@ -49,6 +49,8 @@ public class ComposerHostedDownloadHandler
         throw new IllegalStateException("Unsupported assetKind: " + assetKind);
       case PROVIDER:
         return HttpResponses.ok(hostedFacet.getProviderJson(getVendorToken(context), getProjectToken(context)));
+      case PACKAGE:
+        return HttpResponses.ok(hostedFacet.getPackageJson(getVendorToken(context), getProjectToken(context)));
       case ZIPBALL:
         return responseFor(hostedFacet.getZipball(buildZipballPath(context)));
       default:

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
@@ -82,12 +82,27 @@ public class ComposerHostedFacetImpl
   }
 
   @Override
+  @TransactionalTouchMetadata
+  public Content getPackageJson(final String vendor, final String project) throws IOException {
+    return content().get(ComposerPathUtils.buildPackagePath(vendor, project));
+  }
+
+  @Override
   @TransactionalStoreBlob
   public void rebuildProviderJson(final String vendor, final String project) throws IOException {
     StorageTx tx = UnitOfWork.currentTx();
     Content content = composerJsonProcessor.buildProviderJson(getRepository(), tx,
         tx.findComponents(buildQuery(vendor, project), singletonList(getRepository())));
     content().put(ComposerPathUtils.buildProviderPath(vendor, project), content, AssetKind.PROVIDER);
+  }
+
+  @Override
+  @TransactionalStoreBlob
+  public void rebuildPackageJson(final String vendor, final String project) throws IOException {
+    StorageTx tx = UnitOfWork.currentTx();
+    Content content = composerJsonProcessor.buildPackageJson(getRepository(), tx,
+            tx.findComponents(buildQuery(vendor, project), singletonList(getRepository())));
+    content().put(ComposerPathUtils.buildPackagePath(vendor, project), content, AssetKind.PACKAGE);
   }
 
   @VisibleForTesting

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataFacetImpl.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedMetadataFacetImpl.java
@@ -91,6 +91,7 @@ public class ComposerHostedMetadataFacetImpl
       UnitOfWork.begin(getRepository().facet(StorageFacet.class).txSupplier());
       try {
         hostedFacet.rebuildProviderJson(event.getVendor(), event.getProject());
+        hostedFacet.rebuildPackageJson(event.getVendor(), event.getProject());
       }
       finally {
         UnitOfWork.end();

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedRecipe.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedRecipe.groovy
@@ -27,6 +27,7 @@ import org.sonatype.nexus.repository.view.ConfigurableViewFacet
 import org.sonatype.nexus.repository.view.Router
 import org.sonatype.nexus.repository.view.ViewFacet
 
+import static org.sonatype.nexus.repository.composer.internal.AssetKind.PACKAGE
 import static org.sonatype.nexus.repository.composer.internal.AssetKind.PACKAGES
 import static org.sonatype.nexus.repository.composer.internal.AssetKind.PROVIDER
 import static org.sonatype.nexus.repository.composer.internal.AssetKind.ZIPBALL
@@ -93,6 +94,19 @@ class ComposerHostedRecipe
     builder.route(providerMatcher()
         .handler(timingHandler)
         .handler(assetKindHandler.rcurry(PROVIDER))
+        .handler(securityHandler)
+        .handler(exceptionHandler)
+        .handler(handlerContributor)
+        .handler(conditionalRequestHandler)
+        .handler(partialFetchHandler)
+        .handler(contentHeadersHandler)
+        .handler(unitOfWorkHandler)
+        .handler(downloadHandler)
+        .create())
+
+    builder.route(packageMatcher()
+        .handler(timingHandler)
+        .handler(assetKindHandler.rcurry(PACKAGE))
         .handler(securityHandler)
         .handler(exceptionHandler)
         .handler(handlerContributor)

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonMinifier.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonMinifier.java
@@ -1,0 +1,121 @@
+package org.sonatype.nexus.repository.composer.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.*;
+
+@Named
+@Singleton
+public class ComposerJsonMinifier {
+
+    private static final String V2_FORMAT = "composer/2.0";
+    private static final String UNSET_VALUE = "__unset";
+    private static final String MINIFIED_KEY = "minified";
+    private static final String PACKAGES_KEY = "packages";
+
+    public void expand(Map<String, Object> json) {
+        Object format = json.get(MINIFIED_KEY);
+        if (!(format instanceof String) || !format.equals(V2_FORMAT)) {
+            return;
+        }
+
+        Map<String, List<Object>> packages = new LinkedHashMap<>();
+
+        if (json.get(PACKAGES_KEY) instanceof Map) {
+            Map<String, Object> packagesMap = (Map<String, Object>) json.get(PACKAGES_KEY);
+            for (String packageName : packagesMap.keySet()) {
+                List<Object> packageVersions = (List<Object>) packagesMap.get(packageName);
+
+                Map<String, Object> expandedVersion = null;
+                List<Object> expandedVersions = new ArrayList<>();
+
+                for (Object versionObject : packageVersions) {
+                    if (!(versionObject instanceof Map)) {
+                        continue;
+                    }
+
+                    Map<String, Object> version = (Map<String, Object>) versionObject;
+
+                    if (expandedVersion == null) {
+                        expandedVersions.add(version);
+                        expandedVersion = new LinkedHashMap<>(version);
+                        continue;
+                    }
+
+                    for (Map.Entry<String, Object> versionData : version.entrySet()) {
+                        if (versionData.getValue() instanceof String && versionData.getValue().equals(UNSET_VALUE)) {
+                            expandedVersion.remove(versionData.getKey());
+                        } else {
+                            expandedVersion.put(versionData.getKey(), versionData.getValue());
+                        }
+                    }
+
+                    expandedVersions.add(expandedVersion);
+                    expandedVersion = new LinkedHashMap<>(expandedVersion);
+                }
+
+                packages.put(packageName, expandedVersions);
+            }
+        }
+
+        json.put(PACKAGES_KEY, packages);
+        json.remove(MINIFIED_KEY);
+    }
+
+    public void minify(Map<String, Object> json) {
+        Map<String, List<Object>> packages = new LinkedHashMap<>();
+
+        if (json.get(PACKAGES_KEY) instanceof Map) {
+            Map<String, Object> packagesMap = (Map<String, Object>) json.get(PACKAGES_KEY);
+            for (String packageName : packagesMap.keySet()) {
+                List<Object> packageVersions = (List<Object>) packagesMap.get(packageName);
+
+                Map<String, Object> lastKnownVersionData = null;
+                List<Object> minifiedVersions = new ArrayList<>();
+
+                for (Object versionObject : packageVersions) {
+                    if (!(versionObject instanceof Map)) {
+                        continue;
+                    }
+
+                    Map<String, Object> version = (Map<String, Object>) versionObject;
+
+                    if (lastKnownVersionData == null) {
+                        minifiedVersions.add(version);
+                        lastKnownVersionData = new LinkedHashMap<>(version);
+                        continue;
+                    }
+
+                    Map<String, Object> minifiedVersion = new LinkedHashMap<>();
+
+                    for (Map.Entry<String, Object> versionData : version.entrySet()) {
+                        boolean lastContains = lastKnownVersionData.containsKey(versionData.getKey());
+                        Object lastData = lastKnownVersionData.get(versionData.getKey());
+                        Object currentData = versionData.getValue();
+
+                        if (!lastContains || !Objects.equals(lastData, currentData)) {
+                            minifiedVersion.put(versionData.getKey(), currentData);
+                            lastKnownVersionData.put(versionData.getKey(), currentData);
+                        }
+                    }
+
+                    Iterator<Map.Entry<String, Object>> it = lastKnownVersionData.entrySet().iterator();
+                    while (it.hasNext()) {
+                        Map.Entry<String, Object> lastData = it.next();
+                        if (!version.containsKey(lastData.getKey())) {
+                            minifiedVersion.put(lastData.getKey(), UNSET_VALUE);
+                            it.remove();
+                        }
+                    }
+
+                    minifiedVersions.add(minifiedVersion);
+                }
+
+                packages.put(packageName, minifiedVersions);
+            }
+        }
+
+        json.put(PACKAGES_KEY, packages);
+        json.put(MINIFIED_KEY, V2_FORMAT);
+    }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerPackageHandler.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerPackageHandler.java
@@ -1,0 +1,38 @@
+package org.sonatype.nexus.repository.composer.internal;
+
+import org.sonatype.nexus.repository.http.HttpResponses;
+import org.sonatype.nexus.repository.http.HttpStatus;
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Handler;
+import org.sonatype.nexus.repository.view.Response;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ComposerPackageHandler
+        implements Handler
+{
+    public static final String DO_NOT_REWRITE = "ComposerProviderHandler.doNotRewrite";
+
+    private final ComposerJsonProcessor composerJsonProcessor;
+
+    @Inject
+    public ComposerPackageHandler(final ComposerJsonProcessor composerJsonProcessor) {
+        this.composerJsonProcessor = checkNotNull(composerJsonProcessor);
+    }
+
+    @Nonnull
+    @Override
+    public Response handle(@Nonnull final Context context) throws Exception {
+        Response response = context.proceed();
+        if (!Boolean.parseBoolean(context.getRequest().getAttributes().get(DO_NOT_REWRITE, String.class))) {
+            if (response.getStatus().getCode() == HttpStatus.OK && response.getPayload() != null) {
+                response = HttpResponses
+                        .ok(composerJsonProcessor.rewritePackageJson(context.getRepository(), response.getPayload()));
+            }
+        }
+        return response;
+    }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerPathUtils.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerPathUtils.java
@@ -34,6 +34,8 @@ public final class ComposerPathUtils
 
   private static final String PROVIDER_JSON_PATH = "p/%s/%s.json";
 
+  private static final String PACKAGE_JSON_PATH = "p2/%s/%s.json";
+
   private static final String NAME_PATTERN = "%s-%s-%s";
 
   /**
@@ -110,6 +112,25 @@ public final class ComposerPathUtils
     checkNotNull(vendor);
     checkNotNull(project);
     return String.format(PROVIDER_JSON_PATH, vendor, project);
+  }
+
+  /**
+   * Builds the path to a package json file based on the path contained in a particular context. The vendor token and
+   * the project token must be present in the context in order to successfully generate the path.
+   */
+  public static String buildPackagePath(final Context context) {
+    TokenMatcher.State state = context.getAttributes().require(TokenMatcher.State.class);
+    Map<String, String> tokens = state.getTokens();
+    return buildPackagePath(tokens.get(VENDOR_TOKEN), tokens.get(PROJECT_TOKEN));
+  }
+
+  /**
+   * Builds the path to a package json file based on the specified vendor and project tokens.
+   */
+  public static String buildPackagePath(final String vendor, final String project) {
+    checkNotNull(vendor);
+    checkNotNull(project);
+    return String.format(PACKAGE_JSON_PATH, vendor, project);
   }
 
   private ComposerPathUtils() {

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyRecipe.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyRecipe.groovy
@@ -64,6 +64,9 @@ class ComposerProxyRecipe
   ComposerProviderHandler composerProviderHandler
 
   @Inject
+  ComposerPackageHandler composerPackageHandler
+
+  @Inject
   ComposerProxyRecipe(@Named(ProxyType.NAME) final Type type, @Named(ComposerFormat.NAME) final Format format) {
     super(type, format)
   }
@@ -128,6 +131,21 @@ class ComposerProxyRecipe
         .handler(unitOfWorkHandler)
         .handler(proxyHandler)
         .create())
+
+    builder.route(packageMatcher()
+            .handler(timingHandler)
+            .handler(assetKindHandler.rcurry(AssetKind.PACKAGE))
+            .handler(securityHandler)
+            .handler(exceptionHandler)
+            .handler(handlerContributor)
+            .handler(negativeCacheHandler)
+            .handler(conditionalRequestHandler)
+            .handler(partialFetchHandler)
+            .handler(contentHeadersHandler)
+            .handler(composerPackageHandler)
+            .handler(unitOfWorkHandler)
+            .handler(proxyHandler)
+            .create())
 
     builder.route(zipballMatcher()
         .handler(timingHandler)

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerRecipeSupport.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerRecipeSupport.groovy
@@ -142,6 +142,14 @@ abstract class ComposerRecipeSupport
         ))
   }
 
+  static Builder packageMatcher() {
+    new Builder().matcher(
+            LogicMatchers.and(
+                    new ActionMatcher(GET, HEAD),
+                    new TokenMatcher('/p2/{vendor:.+}/{project:.+}.json')
+            ))
+  }
+
   static Builder zipballMatcher() {
     new Builder().matcher(
         LogicMatchers.and(

--- a/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
+++ b/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessorTest.java
@@ -112,6 +112,9 @@ public class ComposerJsonProcessorTest
   @Mock
   private ComposerJsonExtractor composerJsonExtractor;
 
+  @Mock
+  private ComposerJsonMinifier composerJsonMinifier;
+
   @Test
   public void generatePackagesFromList() throws Exception {
     String listJson = readStreamToString(getClass().getResourceAsStream("generatePackagesFromList.list.json"));
@@ -120,7 +123,7 @@ public class ComposerJsonProcessorTest
     when(repository.getUrl()).thenReturn("http://nexus.repo/base/repo");
     when(payload1.openInputStream()).thenReturn(new ByteArrayInputStream(listJson.getBytes(UTF_8)));
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor, composerJsonMinifier);
     Content output = underTest.generatePackagesFromList(repository, payload1);
 
     assertEquals(packagesJson, readStreamToString(output.openInputStream()), true);
@@ -144,7 +147,7 @@ public class ComposerJsonProcessorTest
     when(component3.name()).thenReturn("project1");
     when(component3.version()).thenReturn("version2");
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor, composerJsonMinifier);
     Content output = underTest.generatePackagesFromComponents(repository, asList(component1, component2, component3));
 
     assertEquals(packagesJson, readStreamToString(output.openInputStream()), true);
@@ -158,7 +161,7 @@ public class ComposerJsonProcessorTest
     when(repository.getUrl()).thenReturn("http://nexus.repo/base/repo");
     when(payload1.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson.getBytes(UTF_8)));
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor, composerJsonMinifier);
     Payload output = underTest.rewriteProviderJson(repository, payload1);
 
     assertEquals(outputJson, readStreamToString(output.openInputStream()), true);
@@ -176,7 +179,7 @@ public class ComposerJsonProcessorTest
     when(payload1.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson1.getBytes(UTF_8)));
     when(payload2.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson2.getBytes(UTF_8)));
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor, composerJsonMinifier);
     Payload output = underTest.mergeProviderJson(repository, Arrays.asList(payload1, payload2), time);
 
     assertEquals(outputJson, readStreamToString(output.openInputStream()), true);
@@ -312,7 +315,7 @@ public class ComposerJsonProcessorTest
         .put("foo", singletonMap("foo-key", "foo-value"))
         .build());
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor, composerJsonMinifier);
     Content output = underTest
         .buildProviderJson(repository, storageTx, asList(component1, component2, component3, component4));
 
@@ -329,7 +332,7 @@ public class ComposerJsonProcessorTest
     when(payload1.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson1.getBytes(UTF_8)));
     when(payload2.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson2.getBytes(UTF_8)));
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor, composerJsonMinifier);
     Payload output = underTest.mergePackagesJson(repository, Arrays.asList(payload1, payload2));
 
     assertEquals(outputJson, readStreamToString(output.openInputStream()), true);
@@ -340,7 +343,7 @@ public class ComposerJsonProcessorTest
     String inputJson = readStreamToString(getClass().getResourceAsStream("getDistUrl.json"));
     when(payload1.openInputStream()).thenReturn(new ByteArrayInputStream(inputJson.getBytes(UTF_8)));
 
-    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor);
+    ComposerJsonProcessor underTest = new ComposerJsonProcessor(composerJsonExtractor, composerJsonMinifier);
     String distUrl = underTest.getDistUrl("vendor1", "project1", "2.0.0", payload1);
 
     assertThat(distUrl, is("https://git.example.com/zipball/418e708b379598333d0a48954c0fa210437795be"));

--- a/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyFacetImplTest.java
+++ b/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyFacetImplTest.java
@@ -292,7 +292,7 @@ public class ComposerProxyFacetImplTest
     when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
 
     when(viewFacet.dispatch(any(Request.class), eq(context))).thenReturn(response);
-    when(composerJsonProcessor.getDistUrl("vendor", "project", "version", payload)).thenReturn("distUrl");
+    when(composerJsonProcessor.getDistUrlFromPackage("vendor", "project", "version", payload)).thenReturn("distUrl");
 
     when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
         .put("vendor", "vendor")

--- a/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromComponents.json
+++ b/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromComponents.json
@@ -1,5 +1,6 @@
 {
   "providers-url": "http://nexus.repo/base/repo/p/%package%.json",
+  "metadata-url": "http://nexus.repo/base/repo/p2/%package%.json",
   "providers": {
     "vendor1/project1": {
       "sha256": null

--- a/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromList.packages.json
+++ b/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromList.packages.json
@@ -1,5 +1,6 @@
 {
   "providers-url": "http://nexus.repo/base/repo/p/%package%.json",
+  "metadata-url": "http://nexus.repo/base/repo/p2/%package%.json",
   "providers": {
     "vendor2/project2": {
       "sha256": null

--- a/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergePackagesJson.output.json
+++ b/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergePackagesJson.output.json
@@ -1,5 +1,6 @@
 {
   "providers-url": "http://nexus.repo/base/repo/p/%package%.json",
+  "metadata-url": "http://nexus.repo/base/repo/p2/%package%.json",
   "providers": {
     "vendor1/project1": {
       "sha256": null


### PR DESCRIPTION
This should add compatibility with composer v2 api.
New packages on packagist can not be access over composer v1 api anymore. For this reason we urgently NEED to address this quickly.

This pull request makes the following changes:
* The changes are not by me, but @eplightning who seems to use the forked version in production somewhere.

It relates to the following issue #s:
* Fixes #93
* Replaces PR https://github.com/sonatype-nexus-community/nexus-repository-composer/pull/97