### PR TITLE
Support for preemptive authentification

### DIFF
--- a/nexus-repository-composer/src/main/resources/static/rapture/NX/composer/view/repository/recipe/ComposerProxy.js
+++ b/nexus-repository-composer/src/main/resources/static/rapture/NX/composer/view/repository/recipe/ComposerProxy.js
@@ -35,7 +35,7 @@ Ext.define('NX.composer.view.repository.recipe.ComposerProxy', {
       {xtype: 'nx-coreui-repository-proxy-facet'},
       {xtype: 'nx-coreui-repository-storage-facet'},
       {xtype: 'nx-coreui-repository-negativecache-facet'},
-      {xtype: 'nx-coreui-repository-httpclient-facet'}
+      {xtype: 'nx-coreui-repository-httpclient-facet-with-preemptive-auth'}
     ];
 
     me.callParent();


### PR DESCRIPTION
This will close #54 as it "borrows" the settings used for the Maven 2 repository for preemptive authentication. While those are made specifically for Maven 2, from looking at the code I don't see why we can't just use this logic, it is generally available for the HTTP client and works.

This pull request makes the following changes:
* It switches out the "normal" HTTP Client facet changes with a component that shows the checkbox for enabling preemptive auth.

It relates to the following issue:
* Fixes #54

This is part of an effort of me to implement better proxying support. Next up I will look into fixing #85. Once that's done and PR #100 is merged this plugin should be able to proxy all Composer 1 and Composer 2 repos.