### PR TITLE
Update to use new version of nexus 3.38+

### DIFF
--- a/.circleci/circleci-readme.md
+++ b/.circleci/circleci-readme.md
@@ -11,6 +11,6 @@ The local build runs in a docker container.
 
   * Run a local build with the following command:
           
-        circleci local execute -c .circleci/local-config.yml --job 'github-maven-deploy/build-and-test'
+        circleci local execute -c .circleci/local-config.yml --job 'build_and_test'
 
     With the above command, those operations what cannot occur locally will show an error (like `Error: FAILED with error not supported`), but the build will proceed and can complete “successfully”, which allows you to verify scripts in your config, etc.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,8 @@
 version: 2.1
 
 orbs:
-  github-maven-deploy: github-maven-deploy/github-maven-deploy@1.0.5
+  maven: circleci/maven@1.2.0
   circleci-maven-release-orb: sonatype-nexus-community/circleci-maven-release-orb@0.0.16
-
-build-and-test-commands: &build-and-test-commands
-  mvn-build-test-command: mvn clean verify -PbuildKar -Dit
-  mvn-collect-artifacts-command: |
-    mkdir -p ~/project/artifacts/junit/
-    find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/project/artifacts/junit/ \;
-    find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} ~/project/artifacts/junit/ \;
 
 release-args: &release-args
   mvn-release-perform-command: mvn --batch-mode release:perform -s .circleci/.maven.xml -PbuildKar
@@ -19,11 +12,38 @@ release-args: &release-args
     branches:
       only: master
 
+jobs:
+  build_and_test:
+    docker:
+      - image: 'cimg/openjdk:8.0'
+    steps:
+      - checkout
+      - maven/with_cache:
+          verify_dependencies: false
+          steps:
+            - run:
+                name: Run Maven Build
+                command: |
+                  mvn clean --batch-mode verify -PbuildKar -Dit
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/project/artifacts/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/project/artifacts/junit/ \;
+            find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} ~/project/artifacts/junit/ \;
+            mkdir -p ~/project/artifacts/it-reports/
+            find . -type f -regex ".*/target/it-reports/.*" -exec cp {} ~/project/artifacts/it-reports/ \;
+          when: always
+      - store_test_results:
+          path: ~/project/artifacts/junit
+      - store_artifacts:
+          path: ~/project/artifacts/it-reports
+
+
 workflows:
   build-branch:
     jobs:
-      - github-maven-deploy/build-and-test:
-          <<: *build-and-test-commands
+      - build_and_test:
           filters:
             branches:
               ignore: master
@@ -42,12 +62,11 @@ workflows:
 
   release-from-master:
     jobs:
-      - github-maven-deploy/build-and-test:
-          <<: *build-and-test-commands
+      - build_and_test:
           filters:
             branches:
               only: master
       - circleci-maven-release-orb/run-maven-release:
           requires:
-            - github-maven-deploy/build-and-test
+            - build_and_test
           <<: *release-args

--- a/nexus-repository-composer/pom.xml
+++ b/nexus-repository-composer/pom.xml
@@ -21,6 +21,13 @@
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-repository</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-repository-content</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -50,6 +57,16 @@
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <version>1.5.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- @todo remove explicit dependency on org.apache.geronimo.specs:geronimo-atinject_1.0_spec:jar:1.0
+    When testing removal of this dependency, be sure to delete geronimo-atinject_1.0_spec from you local .m2 cache
+    fixes IT runtime error: Could not find artifact org.apache.geronimo.specs:geronimo-atinject_1.0_spec:jar:1.0
+    -->
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-atinject_1.0_spec</artifactId>
+      <version>1.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerRecipeSupport.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerRecipeSupport.groovy
@@ -20,7 +20,7 @@ import org.sonatype.nexus.repository.RecipeSupport
 import org.sonatype.nexus.repository.Type
 import org.sonatype.nexus.repository.attributes.AttributesFacet
 import org.sonatype.nexus.repository.http.PartialFetchHandler
-import org.sonatype.nexus.repository.search.SearchFacet
+import org.sonatype.nexus.repository.search.ElasticSearchFacet
 import org.sonatype.nexus.repository.security.SecurityHandler
 import org.sonatype.nexus.repository.storage.SingleAssetComponentMaintenance
 import org.sonatype.nexus.repository.storage.StorageFacet
@@ -77,7 +77,7 @@ abstract class ComposerRecipeSupport
   Provider<StorageFacet> storageFacet
 
   @Inject
-  Provider<SearchFacet> searchFacet
+  Provider<ElasticSearchFacet> searchFacet
 
   @Inject
   Provider<AttributesFacet> attributesFacet

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerRecipeSupport.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerRecipeSupport.groovy
@@ -19,8 +19,8 @@ import org.sonatype.nexus.repository.Format
 import org.sonatype.nexus.repository.RecipeSupport
 import org.sonatype.nexus.repository.Type
 import org.sonatype.nexus.repository.attributes.AttributesFacet
+import org.sonatype.nexus.repository.content.search.SearchFacet
 import org.sonatype.nexus.repository.http.PartialFetchHandler
-import org.sonatype.nexus.repository.search.ElasticSearchFacet
 import org.sonatype.nexus.repository.security.SecurityHandler
 import org.sonatype.nexus.repository.storage.SingleAssetComponentMaintenance
 import org.sonatype.nexus.repository.storage.StorageFacet
@@ -77,7 +77,7 @@ abstract class ComposerRecipeSupport
   Provider<StorageFacet> storageFacet
 
   @Inject
-  Provider<ElasticSearchFacet> searchFacet
+  Provider<SearchFacet> searchFacet
 
   @Inject
   Provider<AttributesFacet> attributesFacet

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.30.0-01</version>
+    <version>3.38.0-01</version>
   </parent>
 
   <artifactId>composer-parent</artifactId>
@@ -42,7 +42,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.30.0-01</nxrm-version>
+    <nxrm-version>3.38.0-01</nxrm-version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.38.0-01</version>
+    <version>3.38.1-01</version>
   </parent>
 
   <artifactId>composer-parent</artifactId>
@@ -42,7 +42,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.38.0-01</nxrm-version>
+    <nxrm-version>3.38.1-01</nxrm-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
As explained in the https://github.com/sonatype-nexus-community/nexus-repository-composer/issues/103 the new version of Nexus have changed SearchFacet and we should use the new version ElasticSearchFacet instead.

This pull request makes the following changes:
* Usage of ElasticSearchFacet instead of SearchFacet

It relates to the following issues:
* [Compatibility with Nexus 3.38.0+](https://github.com/sonatype-nexus-community/nexus-repository-composer/issues/103)
