### PR TITLE
API for Composer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ release-args: &release-args
 jobs:
   build_and_test:
     docker:
-      - image: 'cimg/openjdk:8.0'
+      - image: 'cimg/openjdk:17.0.3'
     steps:
       - checkout
       - maven/with_cache:

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ContentDisposition.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ContentDisposition.java
@@ -1,0 +1,32 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+/**
+ * @since 3.33
+ */
+public enum ContentDisposition
+{
+  INLINE("inline"),
+  ATTACHMENT("attachment");
+
+  private final String value;
+
+  ContentDisposition(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/LayoutPolicy.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/LayoutPolicy.java
@@ -1,0 +1,31 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+/**
+ * Layout policy.
+ *
+ * @since 3.0
+ */
+public enum LayoutPolicy
+{
+  /**
+   * Only allow repository paths that are Composer standard layout compliant.
+   */
+  STRICT,
+
+  /**
+   * Allow any repository paths.
+   */
+  PERMISSIVE
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/VersionPolicy.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/VersionPolicy.java
@@ -1,0 +1,36 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+/**
+ * Repository version policy.
+ *
+ * @since 3.0
+ */
+public enum VersionPolicy
+{
+  /**
+   * Only release coordinates allowed.
+   */
+  RELEASE,
+
+  /**
+   * Only snapshot coordinate allowed.
+   */
+  SNAPSHOT,
+
+  /**
+   * Both kind of coordinates allowed.
+   */
+  MIXED
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerApiRepositoryAdapter.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerApiRepositoryAdapter.java
@@ -1,0 +1,101 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.api;
+
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.composer.internal.rest.HttpClientAttributesWithPreemptiveAuth;
+import org.sonatype.nexus.repository.composer.internal.rest.HttpClientConnectionAuthenticationAttributesWithPreemptive;
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.rest.api.SimpleApiRepositoryAdapter;
+import org.sonatype.nexus.repository.rest.api.model.AbstractApiRepository;
+import org.sonatype.nexus.repository.rest.api.model.HttpClientAttributes;
+import org.sonatype.nexus.repository.routing.RoutingRuleStore;
+import org.sonatype.nexus.repository.types.HostedType;
+import org.sonatype.nexus.repository.types.ProxyType;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Adapter to expose composer specific repository configuration for the repositories REST API.
+ *
+ * @since 3.20
+ */
+@Named(ComposerFormat.NAME)
+public class ComposerApiRepositoryAdapter
+    extends SimpleApiRepositoryAdapter
+{
+  private static final String COMPOSER = "composer";
+
+  @Inject
+  public ComposerApiRepositoryAdapter(final RoutingRuleStore routingRuleStore) {
+    super(routingRuleStore);
+  }
+
+  @Override
+  public AbstractApiRepository adapt(final Repository repository) {
+    boolean online = repository.getConfiguration().isOnline();
+    String name = repository.getName();
+    String url = repository.getUrl();
+
+    switch (repository.getType().toString()) {
+      case HostedType.NAME:
+        return new ComposerHostedApiRepository(
+            name,
+            url,
+            online,
+            getHostedStorageAttributes(repository),
+            getCleanupPolicyAttributes(repository),
+            createComposerAttributes(repository),
+            getComponentAttributes(repository));
+      case ProxyType.NAME:
+        return new ComposerProxyApiRepository(name, url, online,
+            getHostedStorageAttributes(repository),
+            getCleanupPolicyAttributes(repository),
+            getProxyAttributes(repository),
+            getNegativeCacheAttributes(repository),
+            getHttpClientAttributes(repository),
+            getRoutingRuleName(repository),
+            createComposerAttributes(repository));
+      default:
+        return super.adapt(repository);
+    }
+  }
+
+  private ComposerAttributes createComposerAttributes(final Repository repository) {
+    String versionPolicy = repository.getConfiguration().attributes(COMPOSER).get("versionPolicy", String.class);
+    String layoutPolicy = repository.getConfiguration().attributes(COMPOSER).get("layoutPolicy", String.class);
+    String contentDisposition = repository.getConfiguration().attributes(COMPOSER).get("contentDisposition", String.class);
+    return new ComposerAttributes(versionPolicy, layoutPolicy, contentDisposition);
+  }
+
+  @Override
+  protected HttpClientAttributesWithPreemptiveAuth getHttpClientAttributes(final Repository repository) {
+    HttpClientAttributes httpClientAttributes = super.getHttpClientAttributes(repository);
+    HttpClientConnectionAuthenticationAttributesWithPreemptive authentication = null;
+
+    Configuration configuration = repository.getConfiguration();
+    NestedAttributesMap httpclient = configuration.attributes("httpclient");
+    if (httpclient.contains("authentication")) {
+      NestedAttributesMap authenticationMap = httpclient.child("authentication");
+      Boolean preemptive = authenticationMap.get("preemptive", Boolean.class);
+
+      authentication = new HttpClientConnectionAuthenticationAttributesWithPreemptive(httpClientAttributes.getAuthentication(),
+          preemptive);
+    }
+
+    return new HttpClientAttributesWithPreemptiveAuth(httpClientAttributes, authentication);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerAttributes.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerAttributes.java
@@ -35,7 +35,7 @@ public class ComposerAttributes
       allowableValues = "STRICT,PERMISSIVE",
       example = "STRICT")
   @NotEmpty
-  protected final String layoutPolicy;
+  private final String layoutPolicy;
 
   @ApiModelProperty(value = "Content Disposition",
       allowableValues = "INLINE,ATTACHMENT", example = "ATTACHMENT")

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerAttributes.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerAttributes.java
@@ -29,7 +29,7 @@ public class ComposerAttributes
       allowableValues = "RELEASE,SNAPSHOT,MIXED",
       example = "MIXED")
   @NotEmpty
-  protected final String versionPolicy;
+  private final String versionPolicy;
 
   @ApiModelProperty(value = "Validate that all paths are composer artifact or metadata paths",
       allowableValues = "STRICT,PERMISSIVE",

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerAttributes.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerAttributes.java
@@ -1,0 +1,67 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotEmpty;
+
+/**
+ * REST API model for describing composer specific repository properties.
+ *
+ * @since 3.20
+ */
+public class ComposerAttributes
+{
+  @ApiModelProperty(value = "What type of artifacts does this repository store?",
+      allowableValues = "RELEASE,SNAPSHOT,MIXED",
+      example = "MIXED")
+  @NotEmpty
+  protected final String versionPolicy;
+
+  @ApiModelProperty(value = "Validate that all paths are composer artifact or metadata paths",
+      allowableValues = "STRICT,PERMISSIVE",
+      example = "STRICT")
+  @NotEmpty
+  protected final String layoutPolicy;
+
+  @ApiModelProperty(value = "Content Disposition",
+      allowableValues = "INLINE,ATTACHMENT", example = "ATTACHMENT")
+  @NotEmpty
+  private final String contentDisposition;
+
+  @JsonCreator
+  public ComposerAttributes(
+      @JsonProperty("versionPolicy") final String versionPolicy,
+      @JsonProperty("layoutPolicy") final String layoutPolicy,
+      @JsonProperty("contentDisposition") final String contentDisposition)
+  {
+    this.versionPolicy = versionPolicy;
+    this.layoutPolicy = layoutPolicy;
+    this.contentDisposition = contentDisposition;
+  }
+
+  public String getVersionPolicy() {
+    return versionPolicy;
+  }
+
+  public String getLayoutPolicy() {
+    return layoutPolicy;
+  }
+
+  public String getContentDisposition() {
+    return contentDisposition;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerHostedApiRepository.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerHostedApiRepository.java
@@ -1,0 +1,55 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.rest.api.model.CleanupPolicyAttributes;
+import org.sonatype.nexus.repository.rest.api.model.ComponentAttributes;
+import org.sonatype.nexus.repository.rest.api.model.HostedStorageAttributes;
+import org.sonatype.nexus.repository.rest.api.model.SimpleApiHostedRepository;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * REST API model for a composer hosted repository.
+ *
+ * @since 3.20
+ */
+@JsonIgnoreProperties(value = {"format", "type", "url"}, allowGetters = true)
+public class ComposerHostedApiRepository
+    extends SimpleApiHostedRepository
+{
+  @NotNull
+  protected final ComposerAttributes composer;
+
+  @JsonCreator
+  public ComposerHostedApiRepository(
+      @JsonProperty("name") final String name,
+      @JsonProperty("url") final String url,
+      @JsonProperty("online") final Boolean online,
+      @JsonProperty("storage") final HostedStorageAttributes storage,
+      @JsonProperty("cleanup") final CleanupPolicyAttributes cleanup,
+      @JsonProperty("composer") final ComposerAttributes composer,
+      @JsonProperty("component") final ComponentAttributes component)
+  {
+    super(name, ComposerFormat.NAME, url, online, storage, cleanup, component);
+    this.composer = composer;
+  }
+
+  public ComposerAttributes getComposer() {
+    return composer;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerProxyApiRepository.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/api/ComposerProxyApiRepository.java
@@ -1,0 +1,58 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.composer.internal.rest.HttpClientAttributesWithPreemptiveAuth;
+import org.sonatype.nexus.repository.rest.api.model.*;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * REST API model for a composer proxy repository.
+ *
+ * @since 3.20
+ */
+@JsonIgnoreProperties(value = {"format", "type", "url"}, allowGetters = true)
+public class ComposerProxyApiRepository
+    extends SimpleApiProxyRepository
+{
+  @NotNull
+  protected final ComposerAttributes composer;
+
+  @SuppressWarnings("squid:S00107") // suppress constructor parameter count
+  @JsonCreator
+  public ComposerProxyApiRepository(
+      @JsonProperty("name") final String name,
+      @JsonProperty("url") final String url,
+      @JsonProperty("online") final Boolean online,
+      @JsonProperty("storage") final StorageAttributes storage,
+      @JsonProperty("cleanup") final CleanupPolicyAttributes cleanup,
+      @JsonProperty("proxy") final ProxyAttributes proxy,
+      @JsonProperty("negativeCache") final NegativeCacheAttributes negativeCache,
+      @JsonProperty("httpClient") final HttpClientAttributesWithPreemptiveAuth httpClient,
+      @JsonProperty("routingRuleName") final String routingRuleName,
+      @JsonProperty("composer") final ComposerAttributes composer)
+
+  {
+    super(name, ComposerFormat.NAME, url, online, storage, cleanup, proxy, negativeCache, httpClient, routingRuleName);
+    this.composer = composer;
+  }
+
+  public ComposerAttributes getComposer() {
+    return composer;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerGroupRepositoriesApiResource.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerGroupRepositoriesApiResource.java
@@ -1,0 +1,66 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import io.swagger.annotations.*;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.sonatype.nexus.repository.rest.api.AbstractGroupRepositoriesApiResource;
+import org.sonatype.nexus.validation.Validate;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+import static org.sonatype.nexus.rest.ApiDocConstants.*;
+
+/**
+ * @since 3.24
+ */
+@Api(value = API_REPOSITORY_MANAGEMENT)
+public abstract class ComposerGroupRepositoriesApiResource
+    extends AbstractGroupRepositoriesApiResource<ComposerGroupRepositoryApiRequest>
+{
+  @ApiOperation("Create Composer group repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 201, message = REPOSITORY_CREATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @POST
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response createRepository(final ComposerGroupRepositoryApiRequest request) {
+    return super.createRepository(request);
+  }
+
+  @ApiOperation("Update Composer group repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 204, message = REPOSITORY_UPDATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @PUT
+  @Path("/{repositoryName}")
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response updateRepository(
+      final ComposerGroupRepositoryApiRequest request,
+      @ApiParam(value = "Name of the repository to update") @PathParam("repositoryName") final String repositoryName)
+  {
+    return super.updateRepository(request, repositoryName);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerGroupRepositoriesApiResourceBeta.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerGroupRepositoriesApiResourceBeta.java
@@ -1,0 +1,37 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import io.swagger.annotations.Api;
+import org.sonatype.nexus.repository.rest.api.RepositoriesApiResourceBeta;
+import org.sonatype.nexus.rest.APIConstants;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.Path;
+
+/**
+ * @since 3.26
+ * @deprecated the 'beta' prefix is being phased out, prefer starting new APIs with {@link APIConstants#V1_API_PREFIX}
+ * instead. Support backward compatibility.
+ */
+@Api(hidden = true)
+@Named
+@Singleton
+@Path(ComposerGroupRepositoriesApiResourceBeta.RESOURCE_URI)
+@Deprecated
+public class ComposerGroupRepositoriesApiResourceBeta
+    extends ComposerGroupRepositoriesApiResource
+{
+  static final String RESOURCE_URI = RepositoriesApiResourceBeta.RESOURCE_URI + "/composer/group";
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerGroupRepositoriesApiResourceV1.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerGroupRepositoriesApiResourceV1.java
@@ -1,0 +1,31 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import org.sonatype.nexus.repository.rest.api.RepositoriesApiResourceV1;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.Path;
+
+/**
+ * @since 3.26
+ */
+@Named
+@Singleton
+@Path(ComposerGroupRepositoriesApiResourceV1.RESOURCE_URI)
+public class ComposerGroupRepositoriesApiResourceV1
+    extends ComposerGroupRepositoriesApiResource
+{
+  static final String RESOURCE_URI = RepositoriesApiResourceV1.RESOURCE_URI + "/composer/group";
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerGroupRepositoryApiRequest.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerGroupRepositoryApiRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.rest.api.model.GroupAttributes;
+import org.sonatype.nexus.repository.rest.api.model.GroupRepositoryApiRequest;
+import org.sonatype.nexus.repository.rest.api.model.StorageAttributes;
+
+/**
+ * @since 3.24
+ */
+@JsonIgnoreProperties({"format", "type"})
+public class ComposerGroupRepositoryApiRequest
+    extends GroupRepositoryApiRequest
+{
+  @JsonCreator
+  public ComposerGroupRepositoryApiRequest(
+      @JsonProperty("name") final String name,
+      @JsonProperty("online") final Boolean online,
+      @JsonProperty("storage") final StorageAttributes storage,
+      @JsonProperty("group") final GroupAttributes group)
+  {
+    super(name, ComposerFormat.NAME, online, storage, group);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoriesApiResource.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoriesApiResource.java
@@ -1,0 +1,78 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import io.swagger.annotations.*;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.sonatype.nexus.repository.composer.internal.api.ComposerHostedApiRepository;
+import org.sonatype.nexus.repository.rest.api.AbstractHostedRepositoriesApiResource;
+import org.sonatype.nexus.repository.rest.api.FormatAndType;
+import org.sonatype.nexus.repository.rest.api.model.AbstractApiRepository;
+import org.sonatype.nexus.validation.Validate;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+import static org.sonatype.nexus.rest.ApiDocConstants.*;
+
+/**
+ * @since 3.20
+ */
+@Api(value = API_REPOSITORY_MANAGEMENT)
+public abstract class ComposerHostedRepositoriesApiResource
+    extends AbstractHostedRepositoriesApiResource<ComposerHostedRepositoryApiRequest>
+{
+
+  @ApiOperation("Create Composer hosted repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 201, message = REPOSITORY_CREATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @POST
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response createRepository(final ComposerHostedRepositoryApiRequest request) {
+    return super.createRepository(request);
+  }
+
+  @ApiOperation("Update Composer hosted repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 204, message = REPOSITORY_UPDATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @PUT
+  @Path("/{repositoryName}")
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response updateRepository(
+      final ComposerHostedRepositoryApiRequest request,
+      @ApiParam(value = "Name of the repository to update") @PathParam("repositoryName") final String repositoryName)
+  {
+    return super.updateRepository(request, repositoryName);
+  }
+
+  @GET
+  @Path("/{repositoryName}")
+  @RequiresAuthentication
+  @Validate
+  @Override
+  @ApiOperation(value = "Get repository", response = ComposerHostedApiRepository.class)
+  public AbstractApiRepository getRepository(@ApiParam(hidden = true) @BeanParam final FormatAndType formatAndType,
+                                             @PathParam("repositoryName") final String repositoryName) {
+    return super.getRepository(formatAndType, repositoryName);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoriesApiResourceBeta.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoriesApiResourceBeta.java
@@ -1,0 +1,37 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import io.swagger.annotations.Api;
+import org.sonatype.nexus.repository.rest.api.RepositoriesApiResourceBeta;
+import org.sonatype.nexus.rest.APIConstants;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.Path;
+
+/**
+ * @since 3.26
+ * @deprecated the 'beta' prefix is being phased out, prefer starting new APIs with {@link APIConstants#V1_API_PREFIX}
+ * instead. Support backward compatibility.
+ */
+@Api(hidden = true)
+@Named
+@Singleton
+@Path(ComposerHostedRepositoriesApiResourceBeta.RESOURCE_URI)
+@Deprecated
+public class ComposerHostedRepositoriesApiResourceBeta
+    extends ComposerHostedRepositoriesApiResource
+{
+  static final String RESOURCE_URI = RepositoriesApiResourceBeta.RESOURCE_URI + "/composer/hosted";
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoriesApiResourceV1.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoriesApiResourceV1.java
@@ -1,0 +1,31 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import org.sonatype.nexus.repository.rest.api.RepositoriesApiResourceV1;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.Path;
+
+/**
+ * @since 3.26
+ */
+@Named
+@Singleton
+@Path(ComposerHostedRepositoriesApiResourceV1.RESOURCE_URI)
+public class ComposerHostedRepositoriesApiResourceV1
+    extends ComposerHostedRepositoriesApiResource
+{
+  static final String RESOURCE_URI = RepositoriesApiResourceV1.RESOURCE_URI + "/composer/hosted";
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoryApiRequest.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoryApiRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.composer.internal.api.ComposerAttributes;
+import org.sonatype.nexus.repository.rest.api.model.CleanupPolicyAttributes;
+import org.sonatype.nexus.repository.rest.api.model.ComponentAttributes;
+import org.sonatype.nexus.repository.rest.api.model.HostedRepositoryApiRequest;
+import org.sonatype.nexus.repository.rest.api.model.HostedStorageAttributes;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * @since 3.20
+ */
+@JsonIgnoreProperties({"format", "type"})
+public class ComposerHostedRepositoryApiRequest
+    extends HostedRepositoryApiRequest
+{
+  @NotNull
+  protected final ComposerAttributes composer;
+
+  @JsonCreator
+  public ComposerHostedRepositoryApiRequest(
+      @JsonProperty("name") final String name,
+      @JsonProperty("online") final Boolean online,
+      @JsonProperty("storage") final HostedStorageAttributes storage,
+      @JsonProperty("cleanup") final CleanupPolicyAttributes cleanup,
+      @JsonProperty("composer") final ComposerAttributes composer,
+      @JsonProperty("component") final ComponentAttributes componentAttributes
+  )
+  {
+    super(name, ComposerFormat.NAME, online, storage, cleanup, componentAttributes);
+    this.composer = composer;
+  }
+
+  public ComposerAttributes getComposer() {
+    return composer;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoryApiRequestToConfigurationConverter.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerHostedRepositoryApiRequestToConfigurationConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.rest.api.HostedRepositoryApiRequestToConfigurationConverter;
+
+import javax.inject.Named;
+
+/**
+ * @since 3.20
+ */
+@Named
+public class ComposerHostedRepositoryApiRequestToConfigurationConverter
+    extends HostedRepositoryApiRequestToConfigurationConverter<ComposerHostedRepositoryApiRequest>
+{
+  private static final String COMPOSER = "composer";
+
+  @Override
+  public Configuration convert(final ComposerHostedRepositoryApiRequest request) {
+    Configuration configuration = super.convert(request);
+    configuration.attributes(COMPOSER).set("versionPolicy", request.getComposer().getVersionPolicy());
+    configuration.attributes(COMPOSER).set("layoutPolicy", request.getComposer().getLayoutPolicy());
+    configuration.attributes(COMPOSER).set("contentDisposition", request.getComposer().getContentDisposition());
+    return configuration;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoriesApiResource.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoriesApiResource.java
@@ -1,0 +1,78 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import io.swagger.annotations.*;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.sonatype.nexus.repository.composer.internal.api.ComposerProxyApiRepository;
+import org.sonatype.nexus.repository.rest.api.AbstractProxyRepositoriesApiResource;
+import org.sonatype.nexus.repository.rest.api.FormatAndType;
+import org.sonatype.nexus.repository.rest.api.model.AbstractApiRepository;
+import org.sonatype.nexus.validation.Validate;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+import static org.sonatype.nexus.rest.ApiDocConstants.*;
+
+/**
+ * @since 3.20
+ */
+@Api(value = API_REPOSITORY_MANAGEMENT)
+public abstract class ComposerProxyRepositoriesApiResource
+    extends AbstractProxyRepositoriesApiResource<ComposerProxyRepositoryApiRequest>
+{
+
+  @ApiOperation("Create Composer proxy repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 201, message = REPOSITORY_CREATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @POST
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response createRepository(final ComposerProxyRepositoryApiRequest request) {
+    return super.createRepository(request);
+  }
+
+  @ApiOperation("Update Composer proxy repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 204, message = REPOSITORY_UPDATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @PUT
+  @Path("/{repositoryName}")
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response updateRepository(
+      final ComposerProxyRepositoryApiRequest request,
+      @ApiParam(value = "Name of the repository to update") @PathParam("repositoryName") final String repositoryName)
+  {
+    return super.updateRepository(request, repositoryName);
+  }
+
+  @GET
+  @Path("/{repositoryName}")
+  @RequiresAuthentication
+  @Validate
+  @ApiOperation(value = "Get repository", response = ComposerProxyApiRepository.class)
+  @Override
+  public AbstractApiRepository getRepository(@ApiParam(hidden = true) @BeanParam final FormatAndType formatAndType,
+                                             @PathParam("repositoryName") final String repositoryName) {
+    return super.getRepository(formatAndType, repositoryName);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoriesApiResourceBeta.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoriesApiResourceBeta.java
@@ -1,0 +1,37 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import io.swagger.annotations.Api;
+import org.sonatype.nexus.repository.rest.api.RepositoriesApiResourceBeta;
+import org.sonatype.nexus.rest.APIConstants;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.Path;
+
+/**
+ * @since 3.26
+ * @deprecated the 'beta' prefix is being phased out, prefer starting new APIs with {@link APIConstants#V1_API_PREFIX}
+ * instead. Support backward compatibility.
+ */
+@Api(hidden = true)
+@Named
+@Singleton
+@Path(ComposerProxyRepositoriesApiResourceBeta.RESOURCE_URI)
+@Deprecated
+public class ComposerProxyRepositoriesApiResourceBeta
+    extends ComposerProxyRepositoriesApiResource
+{
+  static final String RESOURCE_URI = RepositoriesApiResourceBeta.RESOURCE_URI + "/composer/proxy";
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoriesApiResourceV1.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoriesApiResourceV1.java
@@ -1,0 +1,31 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import org.sonatype.nexus.repository.rest.api.RepositoriesApiResourceV1;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.Path;
+
+/**
+ * @since 3.26
+ */
+@Named
+@Singleton
+@Path(ComposerProxyRepositoriesApiResourceV1.RESOURCE_URI)
+public class ComposerProxyRepositoriesApiResourceV1
+    extends ComposerProxyRepositoriesApiResource
+{
+  static final String RESOURCE_URI = RepositoriesApiResourceV1.RESOURCE_URI + "/composer/proxy";
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoryApiRequest.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoryApiRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.composer.internal.api.ComposerAttributes;
+import org.sonatype.nexus.repository.rest.api.model.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+/**
+ * @since 3.20
+ */
+@JsonIgnoreProperties({"format", "type"})
+public class ComposerProxyRepositoryApiRequest
+    extends ProxyRepositoryApiRequest
+{
+  @NotNull
+  protected final ComposerAttributes composer;
+
+  @NotNull
+  @Valid
+  protected final HttpClientAttributesWithPreemptiveAuth httpClient;
+
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  @SuppressWarnings("squid:S00107") // suppress constructor parameter count
+  public ComposerProxyRepositoryApiRequest(
+      @JsonProperty("name") final String name,
+      @JsonProperty("online") final Boolean online,
+      @JsonProperty("storage") final StorageAttributes storage,
+      @JsonProperty("cleanup") final CleanupPolicyAttributes cleanup,
+      @JsonProperty("proxy") final ProxyAttributes proxy,
+      @JsonProperty("negativeCache") final NegativeCacheAttributes negativeCache,
+      @JsonProperty("httpClient") final HttpClientAttributesWithPreemptiveAuth httpClient,
+      @JsonProperty("routingRule") final String routingRule,
+      @JsonProperty("composer") final ComposerAttributes composer)
+  {
+    super(name, ComposerFormat.NAME, online, storage, cleanup, proxy, negativeCache, httpClient, routingRule);
+    this.composer = composer;
+    this.httpClient = httpClient;
+  }
+
+  public ComposerAttributes getComposer() {
+    return composer;
+  }
+
+  @Override
+  public HttpClientAttributesWithPreemptiveAuth getHttpClient() {
+    return httpClient;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoryApiRequestToConfigurationConverter.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/ComposerProxyRepositoryApiRequestToConfigurationConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.rest.api.ProxyRepositoryApiRequestToConfigurationConverter;
+import org.sonatype.nexus.repository.routing.RoutingRuleStore;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Objects;
+
+/**
+ * @since 3.20
+ */
+@Named
+public class ComposerProxyRepositoryApiRequestToConfigurationConverter
+    extends ProxyRepositoryApiRequestToConfigurationConverter<ComposerProxyRepositoryApiRequest>
+{
+  private static final String COMPOSER = "composer";
+
+  @Inject
+  public ComposerProxyRepositoryApiRequestToConfigurationConverter(final RoutingRuleStore routingRuleStore) {
+    super(routingRuleStore);
+  }
+
+  @Override
+  public Configuration convert(final ComposerProxyRepositoryApiRequest request) {
+    Configuration configuration = super.convert(request);
+    configuration.attributes(COMPOSER).set("versionPolicy", request.getComposer().getVersionPolicy());
+    configuration.attributes(COMPOSER).set("layoutPolicy", request.getComposer().getLayoutPolicy());
+    configuration.attributes(COMPOSER).set("contentDisposition", request.getComposer().getContentDisposition());
+    NestedAttributesMap httpclient = configuration.attributes("httpclient");
+    if (Objects.nonNull(httpclient.get("authentication"))) {
+      httpclient.child("authentication").set("preemptive", request.getHttpClient().getAuthentication().isPreemptive());
+    }
+    return configuration;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/HttpClientAttributesWithPreemptiveAuth.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/HttpClientAttributesWithPreemptiveAuth.java
@@ -1,0 +1,58 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.sonatype.nexus.repository.rest.api.model.HttpClientAttributes;
+import org.sonatype.nexus.repository.rest.api.model.HttpClientConnectionAttributes;
+
+import javax.validation.Valid;
+
+/**
+ * REST API model for describing HTTP connection properties for proxy repositories supporting preemptive
+ * authentication.
+ *
+ * @since 3.30
+ */
+public class HttpClientAttributesWithPreemptiveAuth
+    extends HttpClientAttributes
+{
+  @Valid
+  protected final HttpClientConnectionAuthenticationAttributesWithPreemptive authenticationWithPreemptive;
+
+  @JsonCreator
+  public HttpClientAttributesWithPreemptiveAuth(
+      @JsonProperty("blocked") final Boolean blocked,
+      @JsonProperty("autoBlock") final Boolean autoBlock,
+      @JsonProperty("connection") final HttpClientConnectionAttributes connection,
+      @JsonProperty("authentication") final HttpClientConnectionAuthenticationAttributesWithPreemptive authentication)
+  {
+    super(blocked, autoBlock, connection, null);
+    this.authenticationWithPreemptive = authentication;
+  }
+
+  public HttpClientAttributesWithPreemptiveAuth(
+      final HttpClientAttributes httpClientAttributes,
+      final HttpClientConnectionAuthenticationAttributesWithPreemptive authentication)
+  {
+    super(httpClientAttributes.getBlocked(), httpClientAttributes.getAutoBlock(), httpClientAttributes.getConnection(),
+        null);
+    this.authenticationWithPreemptive = authentication;
+  }
+
+  @Override
+  public HttpClientConnectionAuthenticationAttributesWithPreemptive getAuthentication() {
+    return authenticationWithPreemptive;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/HttpClientConnectionAuthenticationAttributesWithPreemptive.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/rest/HttpClientConnectionAuthenticationAttributesWithPreemptive.java
@@ -1,0 +1,58 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.rest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import io.swagger.annotations.ApiModelProperty;
+import org.sonatype.nexus.repository.rest.api.model.HttpClientConnectionAuthenticationAttributes;
+
+/**
+ * REST API model for describing authentication for HTTP connections used by a proxy repository supporting preemptive
+ * authentication.
+ *
+ * @since 3.30
+ */
+public class HttpClientConnectionAuthenticationAttributesWithPreemptive
+    extends HttpClientConnectionAuthenticationAttributes
+{
+  @ApiModelProperty(value = "Whether to use pre-emptive authentication. Use with caution. Defaults to false.",
+      example = "false")
+  protected final Boolean preemptive;
+
+  @JsonCreator
+  public HttpClientConnectionAuthenticationAttributesWithPreemptive(
+      @JsonProperty("type") final String type,
+      @JsonProperty("preemptive") final Boolean preemptive,
+      @JsonProperty("username") final String username,
+      @JsonProperty(value = "password", access = Access.WRITE_ONLY) final String password,
+      @JsonProperty("ntlmHost") final String ntlmHost,
+      @JsonProperty("ntlmDomain") final String ntlmDomain)
+  {
+    super(type, username, password, ntlmHost, ntlmDomain);
+    this.preemptive = preemptive;
+  }
+
+  public HttpClientConnectionAuthenticationAttributesWithPreemptive(
+      final HttpClientConnectionAuthenticationAttributes auth,
+      final Boolean preemptive)
+  {
+    super(auth.getType(), auth.getUsername(), auth.getPassword(), auth.getNtlmHost(), auth.getNtlmDomain());
+    this.preemptive = preemptive;
+  }
+
+  public Boolean isPreemptive() {
+    return preemptive;
+  }
+}

--- a/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/api/ComposerApiRepositoryAdapterTest.java
+++ b/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/api/ComposerApiRepositoryAdapterTest.java
@@ -1,0 +1,151 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.common.app.BaseUrlHolder;
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
+import org.sonatype.nexus.common.event.EventManager;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.Type;
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.composer.internal.ContentDisposition;
+import org.sonatype.nexus.repository.composer.internal.LayoutPolicy;
+import org.sonatype.nexus.repository.composer.internal.VersionPolicy;
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.manager.internal.RepositoryImpl;
+import org.sonatype.nexus.repository.rest.api.model.AbstractApiRepository;
+import org.sonatype.nexus.repository.rest.api.model.SimpleApiGroupRepository;
+import org.sonatype.nexus.repository.routing.RoutingRuleStore;
+import org.sonatype.nexus.repository.types.GroupType;
+import org.sonatype.nexus.repository.types.HostedType;
+import org.sonatype.nexus.repository.types.ProxyType;
+
+import java.util.Arrays;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.AdditionalMatchers.not;
+
+public class ComposerApiRepositoryAdapterTest
+    extends TestSupport
+{
+  private ComposerApiRepositoryAdapter underTest;
+
+  @Mock
+  private RoutingRuleStore routingRuleStore;
+
+  @Before
+  public void setup() {
+    underTest = new ComposerApiRepositoryAdapter(routingRuleStore);
+    BaseUrlHolder.set("http://nexus-url", "");
+  }
+
+  @Test
+  public void testAdapt_groupRepository() throws Exception {
+    // No Composer specific props so simple smoke test
+    Repository repository = createRepository(new GroupType());
+    Configuration configuration = repository.getConfiguration();
+    configuration.attributes("group").set("memberNames", Arrays.asList("a", "b"));
+    repository.update(configuration);
+
+    SimpleApiGroupRepository groupRepository = (SimpleApiGroupRepository) underTest.adapt(repository);
+    assertRepository(groupRepository, "group", true);
+  }
+
+  @Test
+  public void testAdapt_hostedRepository() throws Exception {
+    Repository repository = createRepository(new HostedType(), LayoutPolicy.STRICT, VersionPolicy.MIXED, ContentDisposition.INLINE);
+
+    ComposerHostedApiRepository hostedRepository = (ComposerHostedApiRepository) underTest.adapt(repository);
+    assertRepository(hostedRepository, "hosted", true);
+    assertThat(hostedRepository.getComposer().getLayoutPolicy(), is("STRICT"));
+    assertThat(hostedRepository.getComposer().getVersionPolicy(), is("MIXED"));
+    assertThat(hostedRepository.getComposer().getContentDisposition(), is("INLINE"));
+    // Check fields are populated, actual values validated with SimpleApiRepositoryAdapterTest
+    assertThat(hostedRepository.getCleanup(), nullValue());
+    assertThat(hostedRepository.getStorage(), notNullValue());
+  }
+
+  @Test
+  public void testAdapt_proxyRepository() throws Exception {
+    Repository repository = createRepository(new ProxyType(), LayoutPolicy.STRICT, VersionPolicy.MIXED, ContentDisposition.INLINE);
+
+    ComposerProxyApiRepository proxyRepository = (ComposerProxyApiRepository) underTest.adapt(repository);
+    assertRepository(proxyRepository, "proxy", true);
+    assertThat(proxyRepository.getComposer().getLayoutPolicy(), is("STRICT"));
+    assertThat(proxyRepository.getComposer().getVersionPolicy(), is("MIXED"));
+    assertThat(proxyRepository.getComposer().getContentDisposition(), is("INLINE"));
+    // Check fields are populated, actual values validated with SimpleApiRepositoryAdapterTest
+    assertThat(proxyRepository.getCleanup(), nullValue());
+    assertThat(proxyRepository.getHttpClient(), notNullValue());
+    assertThat(proxyRepository.getNegativeCache(), notNullValue());
+    assertThat(proxyRepository.getProxy(), notNullValue());
+    assertThat(proxyRepository.getStorage(), notNullValue());
+  }
+
+  private static void assertRepository(
+      final AbstractApiRepository repository,
+      final String type,
+      final Boolean online)
+  {
+    assertThat(repository.getFormat(), is("composer"));
+    assertThat(repository.getName(), is("my-repo"));
+    assertThat(repository.getOnline(), is(online));
+    assertThat(repository.getType(), is(type));
+    assertThat(repository.getUrl(), is(BaseUrlHolder.get() + "/repository/my-repo"));
+  }
+
+  private static Configuration config(final String repositoryName) {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.isOnline()).thenReturn(true);
+    when(configuration.getRepositoryName()).thenReturn(repositoryName);
+    when(configuration.attributes(not(eq("composer")))).thenReturn(new NestedAttributesMap("dummy", newHashMap()));
+
+    return configuration;
+  }
+
+  private static Repository createRepository(final Type type) throws Exception {
+    Repository repository = new RepositoryImpl(Mockito.mock(EventManager.class), type, new ComposerFormat());
+    repository.init(config("my-repo"));
+    return repository;
+  }
+
+  private static Repository createRepository(
+      final Type type,
+      final LayoutPolicy layoutPolicy,
+      final VersionPolicy versionPolicy,
+      final ContentDisposition contentDisposition) throws Exception
+  {
+    Repository repository = new RepositoryImpl(Mockito.mock(EventManager.class), type, new ComposerFormat());
+
+    Configuration configuration = config("my-repo");
+    NestedAttributesMap composer = new NestedAttributesMap("composer", newHashMap());
+    composer.set("layoutPolicy", layoutPolicy.toString());
+    composer.set("versionPolicy", versionPolicy.toString());
+    composer.set("contentDisposition", contentDisposition.toString());
+    when(configuration.attributes("composer")).thenReturn(composer);
+    repository.init(configuration);
+    return repository;
+  }
+}


### PR DESCRIPTION
This will close #34. No Scripts need to create composer repositories. 

This pull request makes the following changes:
* Create API for composer

![image](https://user-images.githubusercontent.com/104193142/173022904-a4604937-7797-46a7-9628-76ef8fc7b405.png)

It relates to the following issue #s:
* Fixes #34 
