### PR TITLE
Hosted composer packages available via v2 api

### DIFF
--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedDownloadHandler.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedDownloadHandler.java
@@ -50,7 +50,7 @@ public class ComposerHostedDownloadHandler
       case PROVIDER:
         return HttpResponses.ok(hostedFacet.getProviderJson(getVendorToken(context), getProjectToken(context)));
       case PACKAGE:
-        return HttpResponses.ok(hostedFacet.getPackageJson(getVendorToken(context), getProjectToken(context)));
+        return responseFor(hostedFacet.getPackageJson(getVendorToken(context), getProjectToken(context)));
       case ZIPBALL:
         return responseFor(hostedFacet.getZipball(buildZipballPath(context)));
       default:

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
@@ -84,7 +84,8 @@ public class ComposerHostedFacetImpl
   @Override
   @TransactionalTouchMetadata
   public Content getPackageJson(final String vendor, final String project) throws IOException {
-    return content().get(ComposerPathUtils.buildPackagePath(vendor, project));
+    Content content = content().get(ComposerPathUtils.buildPackagePath(vendor, project));
+    return content != null ? content : content().get(ComposerPathUtils.buildProviderPath(vendor, project));
   }
 
   @Override

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerHostedFacetImpl.java
@@ -85,6 +85,7 @@ public class ComposerHostedFacetImpl
   @TransactionalTouchMetadata
   public Content getPackageJson(final String vendor, final String project) throws IOException {
     Content content = content().get(ComposerPathUtils.buildPackagePath(vendor, project));
+    //check composer v1 packages if v2 Path is invalid
     return content != null ? content : content().get(ComposerPathUtils.buildProviderPath(vendor, project));
   }
 

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyFacetImpl.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyFacetImpl.java
@@ -162,7 +162,7 @@ public class ComposerProxyFacetImpl
     return cacheControllerHolder.require(assetKind.getCacheType());
   }
 
-  private Content generatePackagesJson(final Context context) throws IOException {
+  private Content generatePackagesJson(final Context context) {
     try {
       // TODO: Better logging and error checking on failure/non-200 scenarios
       Request request = new Request.Builder().action(GET).path("/" + LIST_JSON).build();
@@ -203,7 +203,6 @@ public class ComposerProxyFacetImpl
       try {
         String path = "/" + buildPackagePathForDevVersions(vendor, project);
         Payload payload = getPackagePayload(context, path);
-        String url = composerJsonProcessor.getDistUrlFromPackage(vendor, project, version, payload);
         if (payload != null) {
           return composerJsonProcessor.getDistUrlFromPackage(vendor, project, version, payload);
         }


### PR DESCRIPTION
This pull request makes the following changes:
* If content with PackagePath == null, check ProviderPath

It relates to the following issue:
* Fixes #116 
