### PR TITLE
Add rest api to configure composer repositories

### DIFF
--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerGroupRepositoriesApiResource.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerGroupRepositoriesApiResource.java
@@ -1,0 +1,58 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+import org.sonatype.nexus.repository.rest.api.AbstractGroupRepositoriesApiResource;
+import org.sonatype.nexus.validation.Validate;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+
+import static org.sonatype.nexus.rest.ApiDocConstants.API_REPOSITORY_MANAGEMENT;
+import static org.sonatype.nexus.rest.ApiDocConstants.AUTHENTICATION_REQUIRED;
+import static org.sonatype.nexus.rest.ApiDocConstants.INSUFFICIENT_PERMISSIONS;
+import static org.sonatype.nexus.rest.ApiDocConstants.REPOSITORY_CREATED;
+import static org.sonatype.nexus.rest.ApiDocConstants.REPOSITORY_UPDATED;
+
+@Api(value = API_REPOSITORY_MANAGEMENT)
+public abstract class ComposerGroupRepositoriesApiResource extends AbstractGroupRepositoriesApiResource<ComposerGroupRepositoryApiRequest> {
+  @ApiOperation("Create composer group repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 201, message = REPOSITORY_CREATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @POST
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response createRepository(final ComposerGroupRepositoryApiRequest request) {
+    return super.createRepository(request);
+  }
+
+  @ApiOperation("Update composer group repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 204, message = REPOSITORY_UPDATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @PUT
+  @Path("/{repositoryName}")
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response updateRepository(
+      final ComposerGroupRepositoryApiRequest request,
+      @ApiParam(value = "Name of the repository to update") @PathParam("repositoryName") final String repositoryName)
+  {
+    return super.updateRepository(request, repositoryName);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerGroupRepositoriesApiResourceV1.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerGroupRepositoriesApiResourceV1.java
@@ -1,0 +1,15 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.Path;
+
+import org.sonatype.nexus.repository.rest.api.RepositoriesApiResourceV1;
+
+@Named
+@Singleton
+@Path(ComposerGroupRepositoriesApiResourceV1.RESOURCE_URI)
+public class ComposerGroupRepositoriesApiResourceV1 extends ComposerGroupRepositoriesApiResource
+{
+  static final String RESOURCE_URI = RepositoriesApiResourceV1.RESOURCE_URI + "/composer/group";
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerGroupRepositoryApiRequest.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerGroupRepositoryApiRequest.java
@@ -1,0 +1,23 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.rest.api.model.GroupAttributes;
+import org.sonatype.nexus.repository.rest.api.model.GroupRepositoryApiRequest;
+import org.sonatype.nexus.repository.rest.api.model.StorageAttributes;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties({"format", "type"})
+public class ComposerGroupRepositoryApiRequest extends GroupRepositoryApiRequest {
+  @JsonCreator
+  public ComposerGroupRepositoryApiRequest(
+      @JsonProperty("name") final String name,
+      @JsonProperty("online") final Boolean online,
+      @JsonProperty("storage") final StorageAttributes storage,
+      @JsonProperty("group") final GroupAttributes group) {
+    super(name, ComposerFormat.NAME, online, storage, group);
+  }
+
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerGroupRepositoryApiRequestToConfigurationConverter.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerGroupRepositoryApiRequestToConfigurationConverter.java
@@ -1,0 +1,10 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import org.sonatype.nexus.repository.rest.GroupRepositoryApiRequestToConfigurationConverter;
+
+import javax.inject.Named;
+
+@Named
+public class ComposerGroupRepositoryApiRequestToConfigurationConverter extends GroupRepositoryApiRequestToConfigurationConverter<ComposerGroupRepositoryApiRequest> {
+
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerHostedRepositoriesApiResource.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerHostedRepositoriesApiResource.java
@@ -1,0 +1,58 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+import org.sonatype.nexus.repository.rest.api.AbstractHostedRepositoriesApiResource;
+import org.sonatype.nexus.validation.Validate;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+
+import static org.sonatype.nexus.rest.ApiDocConstants.API_REPOSITORY_MANAGEMENT;
+import static org.sonatype.nexus.rest.ApiDocConstants.AUTHENTICATION_REQUIRED;
+import static org.sonatype.nexus.rest.ApiDocConstants.INSUFFICIENT_PERMISSIONS;
+import static org.sonatype.nexus.rest.ApiDocConstants.REPOSITORY_CREATED;
+import static org.sonatype.nexus.rest.ApiDocConstants.REPOSITORY_UPDATED;
+
+@Api(value = API_REPOSITORY_MANAGEMENT)
+public abstract class ComposerHostedRepositoriesApiResource extends AbstractHostedRepositoriesApiResource<ComposerHostedRepositoryApiRequest> {
+  @ApiOperation("Create composer hosted repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 201, message = REPOSITORY_CREATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @POST
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response createRepository(ComposerHostedRepositoryApiRequest request) {
+    return super.createRepository(request);
+  }
+
+  @ApiOperation("Update composer hosted repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 204, message = REPOSITORY_UPDATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @PUT
+  @Path("/{repositoryName}")
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response updateRepository(
+      final ComposerHostedRepositoryApiRequest request,
+      @ApiParam(value = "Name of the repository to update") @PathParam("repositoryName") final String repositoryName)
+  {
+    return super.updateRepository(request, repositoryName);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerHostedRepositoriesApiResourceV1.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerHostedRepositoriesApiResourceV1.java
@@ -1,0 +1,14 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.Path;
+
+import org.sonatype.nexus.repository.rest.api.RepositoriesApiResourceV1;
+
+@Named
+@Singleton
+@Path(ComposerHostedRepositoriesApiResourceV1.RESOURCE_URI)
+public class ComposerHostedRepositoriesApiResourceV1 extends ComposerHostedRepositoriesApiResource {
+  static final String RESOURCE_URI = RepositoriesApiResourceV1.RESOURCE_URI + "/composer/hosted";
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerHostedRepositoryApiRequest.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerHostedRepositoryApiRequest.java
@@ -1,0 +1,25 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.rest.api.model.CleanupPolicyAttributes;
+import org.sonatype.nexus.repository.rest.api.model.ComponentAttributes;
+import org.sonatype.nexus.repository.rest.api.model.HostedRepositoryApiRequest;
+import org.sonatype.nexus.repository.rest.api.model.HostedStorageAttributes;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties({"format", "type"})
+public class ComposerHostedRepositoryApiRequest extends HostedRepositoryApiRequest {
+  @JsonCreator
+  public ComposerHostedRepositoryApiRequest(
+      @JsonProperty("name") final String name,
+      @JsonProperty("online") final Boolean online,
+      @JsonProperty("storage") final HostedStorageAttributes storage,
+      @JsonProperty("cleanup") final CleanupPolicyAttributes cleanup,
+      @JsonProperty("component") final ComponentAttributes componentAttributes)
+  {
+    super(name, ComposerFormat.NAME, online, storage, cleanup, componentAttributes);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerHostedRepositoryApiRequestToConfigurationConverter.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerHostedRepositoryApiRequestToConfigurationConverter.java
@@ -1,0 +1,11 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import javax.inject.Named;
+
+import org.sonatype.nexus.repository.rest.api.HostedRepositoryApiRequestToConfigurationConverter;
+
+@Named
+public class ComposerHostedRepositoryApiRequestToConfigurationConverter extends HostedRepositoryApiRequestToConfigurationConverter<ComposerHostedRepositoryApiRequest>
+{
+
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerProxyRepositoriesApiResource.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerProxyRepositoriesApiResource.java
@@ -1,0 +1,57 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+import org.sonatype.nexus.repository.rest.api.AbstractProxyRepositoriesApiResource;
+import org.sonatype.nexus.validation.Validate;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+
+import static org.sonatype.nexus.rest.ApiDocConstants.API_REPOSITORY_MANAGEMENT;
+import static org.sonatype.nexus.rest.ApiDocConstants.AUTHENTICATION_REQUIRED;
+import static org.sonatype.nexus.rest.ApiDocConstants.INSUFFICIENT_PERMISSIONS;
+import static org.sonatype.nexus.rest.ApiDocConstants.REPOSITORY_CREATED;
+import static org.sonatype.nexus.rest.ApiDocConstants.REPOSITORY_UPDATED;
+
+@Api(value = API_REPOSITORY_MANAGEMENT)
+public abstract class ComposerProxyRepositoriesApiResource extends AbstractProxyRepositoriesApiResource<ComposerProxyRepositoryApiRequest> {
+  @ApiOperation("Create composer proxy repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 201, message = REPOSITORY_CREATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @POST
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response createRepository(final ComposerProxyRepositoryApiRequest request) {
+    return super.createRepository(request);
+  }
+
+  @ApiOperation("Update composer proxy repository")
+  @ApiResponses(value = {
+      @ApiResponse(code = 204, message = REPOSITORY_UPDATED),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  @PUT
+  @Path("/{repositoryName}")
+  @RequiresAuthentication
+  @Validate
+  @Override
+  public Response updateRepository(
+      final ComposerProxyRepositoryApiRequest request,
+      @ApiParam(value = "Name of the repository to update") @PathParam("repositoryName") final String repositoryName) {
+    return super.updateRepository(request, repositoryName);
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerProxyRepositoriesApiResourceV1.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerProxyRepositoriesApiResourceV1.java
@@ -1,0 +1,16 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.Path;
+
+import org.sonatype.nexus.repository.rest.api.RepositoriesApiResourceV1;
+
+@Named
+@Singleton
+@Path(ComposerProxyRepositoriesApiResourceV1.RESOURCE_URI)
+public class ComposerProxyRepositoriesApiResourceV1
+    extends ComposerProxyRepositoriesApiResource
+{
+  static final String RESOURCE_URI = RepositoriesApiResourceV1.RESOURCE_URI + "/composer/proxy";
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerProxyRepositoryApiRequest.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerProxyRepositoryApiRequest.java
@@ -1,0 +1,38 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import org.sonatype.nexus.repository.composer.internal.ComposerFormat;
+import org.sonatype.nexus.repository.rest.api.model.CleanupPolicyAttributes;
+import org.sonatype.nexus.repository.rest.api.model.HttpClientAttributes;
+import org.sonatype.nexus.repository.rest.api.model.NegativeCacheAttributes;
+import org.sonatype.nexus.repository.rest.api.model.ProxyAttributes;
+import org.sonatype.nexus.repository.rest.api.model.ProxyRepositoryApiRequest;
+import org.sonatype.nexus.repository.rest.api.model.ReplicationAttributes;
+import org.sonatype.nexus.repository.rest.api.model.StorageAttributes;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties({"format", "type"})
+public class ComposerProxyRepositoryApiRequest extends ProxyRepositoryApiRequest
+{
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  @SuppressWarnings("squid:S00107") // suppress constructor parameter count
+  public ComposerProxyRepositoryApiRequest(
+      @JsonProperty("name") final String name,
+      @JsonProperty("online") final Boolean online,
+      @JsonProperty("storage") final StorageAttributes storage,
+      @JsonProperty("cleanup") final CleanupPolicyAttributes cleanup,
+      @JsonProperty("proxy") final ProxyAttributes proxy,
+      @JsonProperty("negativeCache")  final NegativeCacheAttributes negativeCache,
+      @JsonProperty("httpClient") final HttpClientAttributes httpClient,
+      @JsonProperty("routingRule") final String routingRule,
+      @JsonProperty("replication") @JsonInclude(value= Include.NON_EMPTY, content=Include.NON_NULL)
+      final ReplicationAttributes replication)
+  {
+    super(name, ComposerFormat.NAME, online, storage, cleanup, proxy, negativeCache, httpClient, routingRule, replication);
+  }
+
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerProxyRepositoryApiRequestToConfigurationConverter.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/rest/ComposerProxyRepositoryApiRequestToConfigurationConverter.java
@@ -1,0 +1,16 @@
+package org.sonatype.nexus.repository.composer.rest;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.sonatype.nexus.repository.rest.api.ProxyRepositoryApiRequestToConfigurationConverter;
+import org.sonatype.nexus.repository.routing.RoutingRuleStore;
+
+@Named
+public class ComposerProxyRepositoryApiRequestToConfigurationConverter extends ProxyRepositoryApiRequestToConfigurationConverter<ComposerProxyRepositoryApiRequest>
+{
+  @Inject
+  public ComposerProxyRepositoryApiRequestToConfigurationConverter(final RoutingRuleStore routingRuleStore) {
+    super(routingRuleStore);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.39.0-01</version>
+    <version>3.41.0-01</version>
   </parent>
 
   <artifactId>composer-parent</artifactId>
@@ -42,7 +42,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.39.0-01</nxrm-version>
+    <nxrm-version>3.41.0-01</nxrm-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This PR adds rest API support to configure composer repositories, which can be used in automated deployment.

Due to the incompatible changes in the 3.41.0-01 release, I had to raise nxrm-version and parent version to 3.41.0-01.
Without this version bump the API for proxy repositories wouldn't work.

This feature has been tested through the nexus embedded API playground.
I haven't been able to find a suitable integration test in the whole nexus-public, so any hint toward such a test would be welcomed.
