### PR TITLE
Add upload GUI  support

### DIFF
--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerUploadHandler.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerUploadHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.rest.UploadDefinitionExtension;
+import org.sonatype.nexus.repository.security.ContentPermissionChecker;
+import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.PartPayload;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Support for uploading components via UI & API
+ *
+ */
+@Named(ComposerFormat.NAME)
+@Singleton
+public class ComposerUploadHandler
+    extends ComposerUploadHandlerSupport
+{
+  @Inject
+  public ComposerUploadHandler(
+      final ContentPermissionChecker contentPermissionChecker,
+      @Named("simple") final VariableResolverAdapter variableResolverAdapter,
+      final Set<UploadDefinitionExtension> uploadDefinitionExtensions)
+  {
+    super(contentPermissionChecker, variableResolverAdapter, uploadDefinitionExtensions, false);
+  }
+
+  @Override
+  protected List<Content> getResponseContents(String vendor, String name, String version, final Repository repository, final Map<String, PartPayload> pathToPayload)
+      throws IOException
+  {
+    ComposerHostedFacet hostedFacet = repository.facet(ComposerHostedFacet.class);
+
+    List<Content> responseContents = Lists.newArrayList();
+    UnitOfWork.begin(repository.facet(StorageFacet.class).txSupplier());
+    try {
+      for (Entry<String, PartPayload> entry : pathToPayload.entrySet()) {
+        PartPayload payload = entry.getValue();
+        hostedFacet.upload(vendor, name, version, null, null, null, payload);
+        Content content = new Content(payload);
+        responseContents.add(content);
+      }
+    }
+    finally {
+      UnitOfWork.end();
+    }
+    return responseContents;
+  }
+}

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerUploadHandlerSupport.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerUploadHandlerSupport.java
@@ -1,0 +1,152 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.composer.internal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.rest.UploadDefinitionExtension;
+import org.sonatype.nexus.repository.security.ContentPermissionChecker;
+import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+import org.sonatype.nexus.repository.upload.AssetUpload;
+import org.sonatype.nexus.repository.upload.ComponentUpload;
+import org.sonatype.nexus.repository.upload.UploadDefinition;
+import org.sonatype.nexus.repository.upload.UploadFieldDefinition;
+import org.sonatype.nexus.repository.upload.UploadFieldDefinition.Type;
+import org.sonatype.nexus.repository.upload.UploadHandlerSupport;
+import org.sonatype.nexus.repository.upload.UploadRegexMap;
+import org.sonatype.nexus.repository.upload.UploadResponse;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.PartPayload;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.prependIfMissing;
+
+/**
+ * Common base for composer upload handlers
+ */
+public abstract class ComposerUploadHandlerSupport
+    extends UploadHandlerSupport
+{
+  protected static final String FILENAME = "filename";
+
+  protected static final String GROUP = "group";
+
+  protected static final String GROUP_HELP_TEXT = "Component Group";
+
+  protected static final String NAME = "name";
+
+  protected static final String NAME_HELP_TEXT = "Component Name";
+
+  protected static final String VERSION = "version";
+
+  protected static final String VERSION_HELP_TEXT = "Component Version";
+
+  protected static final String FIELD_GROUP_NAME = "Component attributes";
+
+  protected final ContentPermissionChecker contentPermissionChecker;
+
+  protected final VariableResolverAdapter variableResolverAdapter;
+
+  protected final boolean datastoreEnabled;
+
+  protected UploadDefinition definition;
+
+  protected ComposerUploadHandlerSupport(
+      final ContentPermissionChecker contentPermissionChecker,
+      final VariableResolverAdapter variableResolverAdapter,
+      final Set<UploadDefinitionExtension> uploadDefinitionExtensions,
+      final boolean datastoreEnabled)
+  {
+    super(uploadDefinitionExtensions);
+    this.contentPermissionChecker = contentPermissionChecker;
+    this.variableResolverAdapter = variableResolverAdapter;
+    this.datastoreEnabled = datastoreEnabled;
+  }
+
+  @Override
+  public UploadResponse handle(final Repository repository, final ComponentUpload upload) throws IOException {
+    log.info("Handling component upload for repository {}", repository.getName());
+
+    String vendor = upload.getFields().get(GROUP).trim();
+    String name = upload.getFields().get(NAME).trim();
+    String version = upload.getFields().get(VERSION).trim();
+    String basePath = upload.getFields().get(GROUP).trim();
+
+    //Data holders for populating the UploadResponse
+    Map<String,PartPayload> pathToPayload = new LinkedHashMap<>();
+
+    for (AssetUpload asset : upload.getAssetUploads()) {
+      String path = normalizePath(basePath + '/' + asset.getFields().get(FILENAME).trim());
+
+      String pathWithPrefix = datastoreEnabled ? prependIfMissing(path, "/") : path;
+      ensurePermitted(repository.getName(), ComposerFormat.NAME, pathWithPrefix, emptyMap());
+
+      pathToPayload.put(path, asset.getPayload());
+    }
+
+    List<Content> responseContents = getResponseContents(vendor, name, version, repository, pathToPayload);
+
+    return new UploadResponse(responseContents, new ArrayList<>(pathToPayload.keySet()));
+  }
+
+  protected abstract List<Content> getResponseContents(String vendor, String name, String version, final Repository repository,
+                                                       final Map<String, PartPayload> pathToPayload)
+      throws IOException;
+
+
+  protected String normalizePath(final String path) {
+    String result = path.replaceAll("/+", "/");
+
+    if (result.startsWith("/")) {
+      result = result.substring(1);
+    }
+
+    if (result.endsWith("/")) {
+      result = result.substring(0, result.length() - 1);
+    }
+
+    return result;
+  }
+
+  @Override
+  public UploadDefinition getDefinition() {
+    if (definition == null) {
+      List<UploadFieldDefinition> componentFields = new ArrayList<>();
+      componentFields.add(new UploadFieldDefinition(GROUP, GROUP_HELP_TEXT, false, Type.STRING, FIELD_GROUP_NAME));
+      componentFields.add(new UploadFieldDefinition(NAME, NAME_HELP_TEXT, false, Type.STRING, FIELD_GROUP_NAME));
+      componentFields.add(new UploadFieldDefinition(VERSION, VERSION_HELP_TEXT, false, Type.STRING, FIELD_GROUP_NAME));
+      definition = getDefinition(ComposerFormat.NAME, false,
+           componentFields,
+          singletonList(new UploadFieldDefinition(FILENAME, false, Type.STRING)),
+          new UploadRegexMap("(.*)", FILENAME));
+    }
+    return definition;
+  }
+
+  @Override
+  public VariableResolverAdapter getVariableResolverAdapter() {
+    return variableResolverAdapter;
+  }
+
+  @Override
+  public ContentPermissionChecker contentPermissionChecker() {
+    return contentPermissionChecker;
+  }
+}

--- a/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerUploadHandlerTest.java
+++ b/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerUploadHandlerTest.java
@@ -1,0 +1,65 @@
+package org.sonatype.nexus.repository.composer.internal;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.rest.UploadDefinitionExtension;
+import org.sonatype.nexus.repository.security.ContentPermissionChecker;
+import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.PartPayload;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class ComposerUploadHandlerTest
+        extends TestSupport {
+
+    @Mock
+    private ContentPermissionChecker contentPermissionChecker;
+
+    @Mock
+    private VariableResolverAdapter variableResolverAdapter;
+
+
+    private final Set<UploadDefinitionExtension> uploadDefinitionExtensions = new LinkedHashSet<>();
+
+    private final ComposerUploadHandler underTest = new ComposerUploadHandler(
+            contentPermissionChecker,
+            variableResolverAdapter,
+            uploadDefinitionExtensions
+    );
+
+    @Test
+    public void testGetResponseContents() throws IOException {
+        // given
+        Repository hostedRepo = mock(Repository.class);
+        ComposerHostedFacet mockFacet = mock(ComposerHostedFacet.class);
+        when(hostedRepo.facet(ComposerHostedFacet.class)).thenReturn(mockFacet);
+        StorageFacet mockStorage = mock(StorageFacet.class);
+        Supplier<StorageTx> mockSupplier = mock(Supplier.class);
+        when(mockStorage.txSupplier()).thenReturn(mockSupplier);
+        when(hostedRepo.facet(StorageFacet.class)).thenReturn(mockStorage);
+        Map<String, PartPayload> pathToPayload = new LinkedHashMap<>();
+        PartPayload payload = mock(PartPayload.class);
+        pathToPayload.put("path", payload);
+        doNothing().when(mockFacet).upload(eq("vendor"), eq("name"), eq("1.2.3"), eq(null), eq(null), eq(null), any(PartPayload.class));
+
+        // when
+        List<Content> contentList = underTest.getResponseContents("vendor", "name", "1.2.3", hostedRepo, pathToPayload);
+
+        // then
+        verify(mockFacet, times(1)).upload(eq("vendor"), eq("name"), eq("1.2.3"), eq(null), eq(null), eq(null), any(PartPayload.class));
+        assertThat(contentList, is(notNullValue()));
+        assertThat(contentList.size(), is(1));
+    }
+}


### PR DESCRIPTION
This PR brings upload GUI support for hosted composer repository.
With this functionality you can upload manually a package from nexus GUI.

It adds the 2 support classes needed and a unit test class.

