### PR TITLE
Return packages.json if packages/list.json does not exist

### DIFF
--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyFacetImpl.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerProxyFacetImpl.java
@@ -103,18 +103,24 @@ public class ComposerProxyFacetImpl
   protected Content store(final Context context, final Content content) throws IOException {
     AssetKind assetKind = context.getAttributes().require(AssetKind.class);
     switch (assetKind) {
-      case PACKAGES:
-        return content().put(PACKAGES_JSON, generatePackagesJson(context), assetKind);
-      case LIST:
-        return content().put(LIST_JSON, content, assetKind);
-      case PROVIDER:
-        return content().put(buildProviderPath(context), content, assetKind);
-      case PACKAGE:
-        return content().put(buildPackagePath(context), content, assetKind);
-      case ZIPBALL:
-        return content().put(buildZipballPath(context), content, assetKind);
-      default:
-        throw new IllegalStateException();
+    case PACKAGES:
+    	Content returnedContent;
+    	try {
+    		returnedContent = generatePackagesJson(context);
+    	} catch (NullPointerException e) {
+    		returnedContent=content;
+    	}
+    	return content().put(PACKAGES_JSON, returnedContent, assetKind);
+    case LIST:
+    	return content().put(LIST_JSON, content, assetKind);
+    case PROVIDER:
+    	return content().put(buildProviderPath(context), content, assetKind);
+    case PACKAGE:
+    	return content().put(buildPackagePath(context), content, assetKind);
+    case ZIPBALL:
+    	return content().put(buildZipballPath(context), content, assetKind);
+    default:
+    	throw new IllegalStateException();
     }
   }
 


### PR DESCRIPTION
If you go to the drupal 7 repository https://packages.drupal.org/7/ you will find that it does not support the packages/list.json url.  In that case we just return the packages.json that was returned.  This was making retrieving packages.json from a nexus proxy for drupal 7 return a status 500 error.

(brief, plain english overview of your changes here)

instead of failing a get for packages.json from a proxy which does not support the packages/list.json url, this change will instead return the original information from the target repository packages.json response.

This pull request makes the following changes:
* when requesting packages.json
* if the target repository does not support the url packages/list.json, return the content from packages.json
* if the target repository supports the ur packages/list.json, return the information from packages/list.json.  This is how previous version (0.0.29 and below) are working

(If there are changes to the UI, please include a screenshot so we
know what to look for!)
no change

(If there are changes to user behavior in general, please make sure to
update the docs, as well)
no change

It relates to the following issue #s:
none
