### PR TITLE
Do not send composer v1 provider-list in `provider` field anymore

### DIFF
--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessor.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessor.java
@@ -107,8 +107,6 @@ public class ComposerJsonProcessor
 
   private static final String REQUIRE_DEV_KEY = "require-dev";
 
-  private static final String SHA256_KEY = "sha256";
-
   private static final String SHASUM_KEY = "shasum";
 
   private static final String SCRIPTS_KEY = "scripts";
@@ -178,8 +176,7 @@ public class ComposerJsonProcessor
     Map<String, Object> packagesJson = new LinkedHashMap<>();
     packagesJson.put(PROVIDERS_URL_KEY, repository.getUrl() + PACKAGE_JSON_PATH);
     packagesJson.put(METADATA_URL_KEY, repository.getUrl() + PACKAGE_V2_JSON_PATH);
-    packagesJson.put(PROVIDERS_KEY, names.stream()
-        .collect(Collectors.toMap((each) -> each, (each) -> singletonMap(SHA256_KEY, null))));
+
     return new Content(new StringPayload(mapper.writeValueAsString(packagesJson), ContentTypes.APPLICATION_JSON));
   }
 

--- a/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromComponents.json
+++ b/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromComponents.json
@@ -1,12 +1,4 @@
 {
   "providers-url": "http://nexus.repo/base/repo/p/%package%.json",
-  "metadata-url": "http://nexus.repo/base/repo/p2/%package%.json",
-  "providers": {
-    "vendor1/project1": {
-      "sha256": null
-    },
-    "vendor2/project2": {
-      "sha256": null
-    }
-  }
+  "metadata-url": "http://nexus.repo/base/repo/p2/%package%.json"
 }

--- a/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromList.packages.json
+++ b/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/generatePackagesFromList.packages.json
@@ -1,15 +1,4 @@
 {
   "providers-url": "http://nexus.repo/base/repo/p/%package%.json",
-  "metadata-url": "http://nexus.repo/base/repo/p2/%package%.json",
-  "providers": {
-    "vendor2/project2": {
-      "sha256": null
-    },
-    "vendor1/project1": {
-      "sha256": null
-    },
-    "vendor3/project3": {
-      "sha256": null
-    }
-  }
+  "metadata-url": "http://nexus.repo/base/repo/p2/%package%.json"
 }

--- a/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergePackagesJson.input1.json
+++ b/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergePackagesJson.input1.json
@@ -1,11 +1,3 @@
 {
-  "providers-url": "http://nexus.repo/base/repo/p/%package%.json",
-  "providers": {
-    "vendor1/project1": {
-      "sha256": null
-    },
-    "vendor2/project2": {
-      "sha256": null
-    }
-  }
+  "providers-url": "http://nexus.repo/base/repo/p/%package%.json"
 }

--- a/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergePackagesJson.input2.json
+++ b/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergePackagesJson.input2.json
@@ -1,14 +1,3 @@
 {
-  "providers-url": "http://nexus.repo/base/repo/p/%package%.json",
-  "providers": {
-    "vendor2/project2": {
-      "sha256": null
-    },
-    "vendor3/project3": {
-      "sha256": null
-    },
-    "vendor4/project4": {
-      "sha256": null
-    }
-  }
+  "providers-url": "http://nexus.repo/base/repo/p/%package%.json"
 }

--- a/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergePackagesJson.output.json
+++ b/nexus-repository-composer/src/test/resources/org/sonatype/nexus/repository/composer/internal/mergePackagesJson.output.json
@@ -1,18 +1,4 @@
 {
   "providers-url": "http://nexus.repo/base/repo/p/%package%.json",
-  "metadata-url": "http://nexus.repo/base/repo/p2/%package%.json",
-  "providers": {
-    "vendor1/project1": {
-      "sha256": null
-    },
-    "vendor2/project2": {
-      "sha256": null
-    },
-    "vendor3/project3": {
-      "sha256": null
-    },
-    "vendor4/project4": {
-      "sha256": null
-    }
-  }
+  "metadata-url": "http://nexus.repo/base/repo/p2/%package%.json"
 }


### PR DESCRIPTION
This pull request makes the following changes:
* removes package list from `packages.json` endpoint as composerV2 does not use it
