### PR TITLE
fix missing cache info on proxy repo components (#160)

### DIFF
--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/ComposerContentFacet.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/ComposerContentFacet.java
@@ -38,7 +38,7 @@ public interface ComposerContentFacet
 
   Optional<Content> get(String path);
 
-  FluentAsset put(String path, Payload payload, AssetKind assetKind) throws IOException;
+  Content put(String path, Payload payload, AssetKind assetKind) throws IOException;
 
   FluentAsset put(String path, Payload payload, String sourceType, String sourceUrl, String sourceReference) throws IOException;
 

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImpl.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImpl.java
@@ -71,19 +71,26 @@ public class ComposerContentFacetImpl
   }
 
   @Override
-  public FluentAsset put(final String path, final Payload payload, final AssetKind assetKind) throws IOException {
+  public Content put(final String path, final Payload payload, final AssetKind assetKind) throws IOException {
     try (TempBlob tempBlob = getTempBlob(payload)) {
+      FluentAsset asset;
       switch (assetKind) {
         case ZIPBALL:
-          return findOrCreateContentAsset(path, tempBlob, assetKind, null, null, null);
+          asset = findOrCreateContentAsset(path, tempBlob, assetKind, null, null, null);
+          break;
         case PACKAGES:
         case PACKAGE:
         case LIST:
         case PROVIDER:
-          return findOrCreateMetadataAsset(path, tempBlob, assetKind);
+          asset = findOrCreateMetadataAsset(path, tempBlob, assetKind);
+          break;
         default:
           throw new IllegalStateException("Unexpected asset kind: " + assetKind);
       }
+
+      return asset
+          .markAsCached(payload)
+          .download();
     }
   }
 

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessor.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerJsonProcessor.java
@@ -12,7 +12,6 @@
  */
 package org.sonatype.nexus.repository.composer.internal;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.hash.Hashing;
@@ -21,6 +20,7 @@ import org.sonatype.nexus.blobstore.api.Blob;
 import org.sonatype.nexus.common.entity.Continuation;
 import org.sonatype.nexus.common.hash.HashAlgorithm;
 import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.cache.CacheInfo;
 import org.sonatype.nexus.repository.composer.ComposerContentFacet;
 import org.sonatype.nexus.repository.content.AssetBlob;
 import org.sonatype.nexus.repository.content.fluent.FluentAsset;
@@ -164,7 +164,14 @@ public class ComposerJsonProcessor
   public Content generatePackagesFromList(final Repository repository, final Payload payload) throws IOException {
     // TODO: Parse using JSON tokens rather than loading all this into memory, it "should" work but I'd be careful.
     Map<String, Object> listJson = parseJson(payload);
-    return buildPackagesJson(repository, new LinkedHashSet<>((Collection<String>) listJson.get(PACKAGE_NAMES_KEY)));
+    Content packagesJson = buildPackagesJson(repository, new LinkedHashSet<>((Collection<String>) listJson.get(PACKAGE_NAMES_KEY)));
+
+    // Preserve caching info from list, if present.
+    if (payload instanceof Content) {
+      packagesJson.getAttributes().set(CacheInfo.class, ((Content) payload).getAttributes().get(CacheInfo.class));
+    }
+
+    return packagesJson;
   }
 
   /**

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/hosted/ComposerHostedUploadHandler.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/hosted/ComposerHostedUploadHandler.java
@@ -181,7 +181,7 @@ public class ComposerHostedUploadHandler
     try (TempBlob blob = contentFacet.blobs().ingest(contentPath, contentType, ComposerContentFacetImpl.hashAlgorithms,
         configuration.isHardLinkingEnabled())) {
       ComposerContentFacet composerFacet = repository.facet(ComposerContentFacet.class);
-      return composerFacet.put(path, new TempBlobPayload(blob, contentType), AssetKind.ZIPBALL).download();
+      return composerFacet.put(path, new TempBlobPayload(blob, contentType), AssetKind.ZIPBALL);
     }
   }
 

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/proxy/ComposerProxyFacet.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/proxy/ComposerProxyFacet.java
@@ -29,7 +29,6 @@ import org.sonatype.nexus.repository.composer.ComposerContentFacet;
 import org.sonatype.nexus.repository.composer.internal.ComposerJsonProcessor;
 import org.sonatype.nexus.repository.config.Configuration;
 import org.sonatype.nexus.repository.content.facet.ContentProxyFacetSupport;
-import org.sonatype.nexus.repository.content.fluent.FluentAsset;
 import org.sonatype.nexus.repository.view.Content;
 import org.sonatype.nexus.repository.view.Context;
 import org.sonatype.nexus.repository.view.Payload;
@@ -115,28 +114,28 @@ public class ComposerProxyFacet
   @Override
   protected Content store(final Context context, final Content content) throws IOException {
     AssetKind assetKind = context.getAttributes().require(AssetKind.class);
-    FluentAsset asset;
+    Content res;
     switch (assetKind) {
       case PACKAGES:
-        asset = content().put(PACKAGES_JSON, generatePackagesJson(context), assetKind);
+        res = content().put(PACKAGES_JSON, generatePackagesJson(context), assetKind);
         break;
       case LIST:
-        asset = content().put(LIST_JSON, content, assetKind);
-      break;
+        res = content().put(LIST_JSON, content, assetKind);
+        break;
       case PROVIDER:
-        asset = content().put(buildProviderPath(context), content, assetKind);
-      break;
+        res = content().put(buildProviderPath(context), content, assetKind);
+        break;
       case PACKAGE:
-        asset = content().put(buildPackagePath(context), content, assetKind);
-      break;
+        res = content().put(buildPackagePath(context), content, assetKind);
+        break;
       case ZIPBALL:
-        asset = content().put(buildZipballPath(context), content, assetKind);
-      break;
+        res = content().put(buildZipballPath(context), content, assetKind);
+        break;
       default:
         throw new IllegalStateException();
     }
 
-    return asset.download();
+    return res;
   }
 
   @Override

--- a/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImplTest.java
+++ b/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerContentFacetImplTest.java
@@ -112,6 +112,8 @@ public class ComposerContentFacetImplTest
   @Mock
   private FluentAsset fluentAsset;
 
+  private Content content;
+
   @Mock
   private FluentComponent fluentComponent;
 
@@ -167,7 +169,10 @@ public class ComposerContentFacetImplTest
     when(fluentAssets.path(anyString())).thenReturn(emptyFAB);
     when(emptyFAB.find()).thenReturn(Optional.empty());
     when(fluentAssetBuilder.find()).thenReturn(Optional.of(fluentAsset));
-    when(fluentAsset.download()).thenReturn(new Content(new BlobPayload(blob, null)));
+
+    content = new Content(new BlobPayload(blob, null));
+    when(fluentAsset.markAsCached(any(Payload.class))).thenReturn(fluentAsset);
+    when(fluentAsset.download()).thenReturn(content);
 
     when(underTest.blobs()).thenReturn(fluentBlobs);
     when(fluentBlobs.ingest(any(Payload.class), any(List.class))).thenReturn(tempBlob);
@@ -265,8 +270,8 @@ public class ComposerContentFacetImplTest
       when(fluentComponentBuilder.getOrCreate()).thenReturn(fluentComponent);
     }
 
-    FluentAsset res = underTest.put(path, upload, assetKind);
-    assertThat(res, is(fluentAsset));
+    Content res = underTest.put(path, upload, assetKind);
+    assertThat(res, is(content));
     assertThat(pathCaptor.getValue(), is(path));
     assertThat(kindCaptor.getValue(), is(assetKind.name()));
     assertThat(tempBlobCaptor.getValue(), is(tempBlob));

--- a/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/proxy/ComposerProxyFacetImplTest.java
+++ b/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/proxy/ComposerProxyFacetImplTest.java
@@ -207,7 +207,7 @@ public class ComposerProxyFacetImplTest
   @Test
   public void storePackages() throws Exception {
     when(contextAttributes.require(AssetKind.class)).thenReturn(PACKAGES);
-    when(composerContentFacet.put(PACKAGES_PATH, content, PACKAGES)).thenReturn(fluentAsset);
+    when(composerContentFacet.put(PACKAGES_PATH, content, PACKAGES)).thenReturn(content);
 
     when(viewFacet.dispatch(any(Request.class), eq(context))).thenReturn(response);
     when(composerJsonProcessor.generatePackagesFromList(repository, payload)).thenReturn(content);
@@ -220,7 +220,7 @@ public class ComposerProxyFacetImplTest
   @Test
   public void storeList() throws Exception {
     when(contextAttributes.require(AssetKind.class)).thenReturn(LIST);
-    when(composerContentFacet.put(LIST_PATH, content, LIST)).thenReturn(fluentAsset);
+    when(composerContentFacet.put(LIST_PATH, content, LIST)).thenReturn(content);
 
     assertThat(underTest.store(context, content), is(content));
 
@@ -232,7 +232,7 @@ public class ComposerProxyFacetImplTest
     when(contextAttributes.require(AssetKind.class)).thenReturn(PROVIDER);
     when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
 
-    when(composerContentFacet.put(PROVIDER_PATH, content, PROVIDER)).thenReturn(fluentAsset);
+    when(composerContentFacet.put(PROVIDER_PATH, content, PROVIDER)).thenReturn(content);
 
     when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
         .put("vendor", "vendor")
@@ -249,7 +249,7 @@ public class ComposerProxyFacetImplTest
     when(contextAttributes.require(AssetKind.class)).thenReturn(ZIPBALL);
     when(contextAttributes.require(TokenMatcher.State.class)).thenReturn(state);
 
-    when(composerContentFacet.put(ZIPBALL_PATH, content, ZIPBALL)).thenReturn(fluentAsset);
+    when(composerContentFacet.put(ZIPBALL_PATH, content, ZIPBALL)).thenReturn(content);
 
     when(state.getTokens()).thenReturn(new ImmutableMap.Builder<String, String>()
         .put("vendor", "vendor")


### PR DESCRIPTION
**This pull request makes the following changes:**

Due to missing cache marking blobs of proxy repos were always stale and fetched again on every request.

Add a call to `markAsCached()` which uses the CacheInfo attribute (only present on proxy components) before calling `download()` to resolve this.

For our generated _packages.json_ we preserve the `CacheInfo` from _list.json_

**It relates to the following issue #s:**
* Fixes #160
