### PR TITLE
fix asset deletion on proxy repositories

### DIFF
--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerMaintenanceFacet.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/ComposerMaintenanceFacet.java
@@ -20,6 +20,7 @@ import org.sonatype.nexus.repository.content.maintenance.LastAssetMaintenanceFac
 
 import javax.inject.Named;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -37,25 +38,29 @@ public class ComposerMaintenanceFacet
 
     String vendor = component.namespace();
     String project = component.name();
-    try {
-      if (!composerHosted().rebuildPackageJson(vendor, project).isPresent()) {
-        deletedPaths.add(ComposerPathUtils.buildPackagePath(vendor, project));
+
+    Optional<ComposerHostedFacet> hostedFacet = composerHosted();
+    if (hostedFacet.isPresent()) {
+      try {
+        if (!hostedFacet.get().rebuildPackageJson(vendor, project).isPresent()) {
+          deletedPaths.add(ComposerPathUtils.buildPackagePath(vendor, project));
+        }
+      } catch (IOException e) {
+        // update failed
       }
-    } catch (IOException e) {
-      // update failed
-    }
-    try {
-      if (!composerHosted().rebuildProviderJson(vendor, project).isPresent()) {
-        deletedPaths.add(ComposerPathUtils.buildProviderPath(vendor, project));
+      try {
+        if (!hostedFacet.get().rebuildProviderJson(vendor, project).isPresent()) {
+          deletedPaths.add(ComposerPathUtils.buildProviderPath(vendor, project));
+        }
+      } catch (IOException e) {
+        // update failed
       }
-    } catch (IOException e) {
-      // update failed
     }
 
     return deletedPaths.build();
   }
 
-  private ComposerHostedFacet composerHosted() {
-    return facet(ComposerHostedFacet.class);
+  private Optional<ComposerHostedFacet> composerHosted() {
+    return optionalFacet(ComposerHostedFacet.class);
   }
 }

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/proxy/ComposerProxyFacet.java
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/proxy/ComposerProxyFacet.java
@@ -223,7 +223,6 @@ public class ComposerProxyFacet
       try {
         String path = buildPackagePathForDevVersions(vendor, project);
         Payload payload = getPackagePayload(context, path);
-        String url = composerJsonProcessor.getDistUrlFromPackage(vendor, project, version, payload);
         if (payload != null) {
           return composerJsonProcessor.getDistUrlFromPackage(vendor, project, version, payload);
         }

--- a/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerMaintenanceFacetTest.java
+++ b/nexus-repository-composer/src/test/java/org/sonatype/nexus/repository/composer/internal/ComposerMaintenanceFacetTest.java
@@ -78,7 +78,7 @@ public class ComposerMaintenanceFacetTest
   public void setUp() throws Exception {
     when(repository.getName()).thenReturn(REPOSITORY_NAME);
     when(repository.facet(ContentFacet.class)).thenReturn(contentFacet);
-    when(repository.facet(ComposerHostedFacet.class)).thenReturn(hostedFacet);
+    when(repository.optionalFacet(ComposerHostedFacet.class)).thenReturn(Optional.of(hostedFacet));
 
     when(contentFacet.components()).thenReturn(fluentComponents);
     when(fluentComponents.with(component)).thenReturn(fluentComponent);
@@ -109,5 +109,12 @@ public class ComposerMaintenanceFacetTest
 
     Set<String> deletedPaths = underTest.deleteComponent(component);
     assertEquals(new HashSet<>(Arrays.asList(ZIPBALL_PATH, PROVIDER_PATH, PACKAGE_PATH)), deletedPaths);
+  }
+
+  @Test
+  public void testDeleteProxyComponent() {
+    when(repository.optionalFacet(ComposerHostedFacet.class)).thenReturn(Optional.empty());
+    Set<String> deletedPaths = underTest.deleteComponent(component);
+    assertEquals(singleton(ZIPBALL_PATH), deletedPaths);
   }
 }


### PR DESCRIPTION
**This pull request makes the following changes:**

Because no hosted facet is attached here asset deletion on zipballs throws a MissingFacetException when trying to rebuild metadata files after deleting a zipball.

In proxy repositories package and provider JSON are cached from upstream and not generated from local repo content, so it's content is still valid after deletion. Add a conditional and only try to rebuild anything if a hosted facet is actually attached.

**Error description:**

![composer-proxy-asset-delete error](https://github.com/user-attachments/assets/2fdae9f4-3124-41fb-bb3a-65e7e6180c00)
(the displayed artifact is randomly picked and has nothing to do with the actual error)

```
org.sonatype.nexus.repository.MissingFacetException: No facet of type ComposerHostedFacet attached to repository composer-proxy
  at org.sonatype.nexus.repository.manager.internal.RepositoryImpl.facet(RepositoryImpl.java:375)
  at org.sonatype.nexus.repository.FacetSupport.facet(FacetSupport.java:224)
  at org.sonatype.nexus.repository.composer.internal.ComposerMaintenanceFacet.composerHosted(ComposerMaintenanceFacet.java:59)
  at org.sonatype.nexus.repository.composer.internal.ComposerMaintenanceFacet.deleteComponent(ComposerMaintenanceFacet.java:41)
  at org.sonatype.nexus.repository.content.maintenance.LastAssetMaintenanceFacet.deleteAsset(LastAssetMaintenanceFacet.java:39)
  at org.sonatype.nexus.repository.content.maintenance.internal.MaintenanceServiceImpl.deleteAsset(MaintenanceServiceImpl.java:93)
  at org.sonatype.nexus.coreui.internal.content.ContentComponentHelper.lambda$9(ContentComponentHelper.java:252)
  at java.base/java.util.Optional.map(Optional.java:260)
  at org.sonatype.nexus.coreui.internal.content.ContentComponentHelper.deleteAsset(ContentComponentHelper.java:252)
  [...]
```