### PR TITLE
High Availability Support

### DIFF
--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/recipe/ComposerGroupRecipe.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/recipe/ComposerGroupRecipe.groovy
@@ -24,6 +24,7 @@ import javax.inject.Named
 import javax.inject.Provider
 import javax.inject.Singleton
 
+import org.sonatype.nexus.common.upgrade.AvailabilityVersion;
 import org.sonatype.nexus.repository.Format
 import org.sonatype.nexus.repository.Repository
 import org.sonatype.nexus.repository.Type
@@ -38,6 +39,7 @@ import org.sonatype.nexus.repository.view.ViewFacet
 /**
  * Recipe for creating a Composer group repository.
  */
+@AvailabilityVersion(from = "1.0")
 @Named(ComposerGroupRecipe.NAME)
 @Singleton
 class ComposerGroupRecipe

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/recipe/ComposerHostedRecipe.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/recipe/ComposerHostedRecipe.groovy
@@ -24,6 +24,7 @@ import javax.inject.Named
 import javax.inject.Provider
 import javax.inject.Singleton
 
+import org.sonatype.nexus.common.upgrade.AvailabilityVersion;
 import org.sonatype.nexus.repository.Format
 import org.sonatype.nexus.repository.Repository
 import org.sonatype.nexus.repository.Type
@@ -42,6 +43,7 @@ import static org.sonatype.nexus.repository.composer.AssetKind.ZIPBALL
 /**
  * Recipe for creating a Composer hosted repository.
  */
+@AvailabilityVersion(from = "1.0")
 @Named(ComposerHostedRecipe.NAME)
 @Singleton
 class ComposerHostedRecipe

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/recipe/ComposerProxyRecipe.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/recipe/ComposerProxyRecipe.groovy
@@ -24,6 +24,7 @@ import javax.inject.Named
 import javax.inject.Provider
 import javax.inject.Singleton
 
+import org.sonatype.nexus.common.upgrade.AvailabilityVersion;
 import org.sonatype.nexus.repository.Format
 import org.sonatype.nexus.repository.Repository
 import org.sonatype.nexus.repository.Type
@@ -41,6 +42,7 @@ import org.sonatype.nexus.repository.view.ViewFacet
 /**
  * Recipe for creating a Composer proxy repository.
  */
+@AvailabilityVersion(from = "1.0")
 @Named(ComposerProxyRecipe.NAME)
 @Singleton
 class ComposerProxyRecipe

--- a/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/recipe/ComposerRecipeSupport.groovy
+++ b/nexus-repository-composer/src/main/java/org/sonatype/nexus/repository/composer/internal/recipe/ComposerRecipeSupport.groovy
@@ -22,6 +22,7 @@ import org.sonatype.nexus.repository.content.browse.BrowseFacet
 import javax.inject.Inject
 import javax.inject.Provider
 
+import org.sonatype.nexus.common.db.DatabaseCheck
 import org.sonatype.nexus.repository.Format
 import org.sonatype.nexus.repository.RecipeSupport
 import org.sonatype.nexus.repository.Type
@@ -67,6 +68,8 @@ abstract class ComposerRecipeSupport
   public static final String SOURCE_URL_FIELD_NAME = 'src-url';
 
   public static final String SOURCE_REFERENCE_FIELD_NAME = 'src-ref';
+
+  private DatabaseCheck databaseCheck;
 
   @Inject
   Provider<ComposerContentFacet> contentFacet
@@ -162,5 +165,19 @@ abstract class ComposerRecipeSupport
             new ActionMatcher(PUT),
             new TokenMatcher('/packages/upload/{vendor:.+}/{project:.+}/{version:.+}')
         ))
+  }
+
+  @Inject
+  public void setDatabaseCheck(final DatabaseCheck databaseCheck) {
+    this.databaseCheck = databaseCheck;
+  }
+
+  @Override
+  public boolean isFeatureEnabled() {
+    if (databaseCheck != null && !databaseCheck.isAllowedByVersion(getClass())) {
+      return false;
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
Hi,

Currently, the plug-in doesn't works with the new [high availability mode](https://help.sonatype.com/en/high-availability-deployment-options.html) of Nexus.

The plug-in can be installed without any error, but when you're trying to configure a new repository, all the composer recipes will not appear in the list of available recipes and the following error will appear in `nexus.log`:

```
2024-10-01 14:56:14,388+0200 ERROR [qtp286980758-317] nexus admin org.sonatype.nexus.repository.db.datastore.DatabaseCheckImpl - Missing database version specified for class org.sonatype.nexus.repository.composer.internal.recipe.ComposerHostedRecipe
2024-10-01 14:56:14,389+0200 ERROR [qtp286980758-317] nexus admin org.sonatype.nexus.repository.db.datastore.DatabaseCheckImpl - Missing database version specified for class org.sonatype.nexus.repository.composer.internal.recipe.ComposerProxyRecipe
2024-10-01 14:56:14,390+0200 ERROR [qtp286980758-317] nexus admin org.sonatype.nexus.repository.db.datastore.DatabaseCheckImpl - Missing database version specified for class org.sonatype.nexus.repository.composer.internal.recipe.ComposerGroupRecipe
```

This PR adds support of the ha mode of Nexus by:
- Adding the AvailabilityVersion annotation for each composer recipes class
- Overriding the isFeatureEnabled method, because composer is not listed in [the immutable list of recipes compatible with the HA mode](https://github.com/sonatype/nexus-public/blob/main/components/nexus-repository-config/src/main/java/org/sonatype/nexus/repository/internal/datastore/DatastoreHighAvailabilitySupportChecker.java#L41)

Let me know if you need any further information.

Regards,
Julien Huon




