### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # declaration of NEXUS_VERSION must appear before first FROM command
 # see: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG NEXUS_VERSION=latest
+ARG NEXUS_VERSION=3.71.0-java17-alpine
 
 FROM maven:3-jdk-8-alpine AS build
 


### PR DESCRIPTION
Different versions of the Nexus Composer plugin are suitable for different versions of Nexus. Writing 'latest' directly will result in always referencing the latest version of Nexus. This is not a problem in the master version, but the old plugin tag version is not compatible with the latest nexus version, so I think each plugin version should clearly specify the corresponding Nexus version
