### PR TITLE
docker: remove official plugin to prevent conflicts on 3.77

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 # declaration of NEXUS_VERSION must appear before first FROM command
-# see: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+# see: https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact
 ARG NEXUS_VERSION=latest
 
-FROM maven:3-jdk-8-alpine AS build
-RUN apk add --no-cache git
+FROM maven:3-eclipse-temurin-17 AS build
 COPY . /nexus-repository-composer/
-RUN cd /nexus-repository-composer/; \
-    mvn clean package -PbuildKar;
+WORKDIR /nexus-repository-composer
+RUN mvn clean package -PbuildKar
 
 FROM sonatype/nexus3:$NEXUS_VERSION
 
 ARG DEPLOY_DIR=/opt/sonatype/nexus/deploy/
 USER root
 COPY --from=build /nexus-repository-composer/nexus-repository-composer/target/nexus-repository-composer-*-bundle.kar ${DEPLOY_DIR}
+
+# Remove official Composer plugin from features (part of the Community Edition since 3.77.0)
+RUN if [ -f "$NEXUS_HOME"/system/com/sonatype/nexus/assemblies/nexus-community-feature/*/nexus-community-feature-*-features.xml ]; then \
+    sed -i 's#<feature[^>]*>nexus-repository-composer</feature>##' "$NEXUS_HOME"/system/com/sonatype/nexus/assemblies/nexus-community-feature/*/nexus-community-feature-*-features.xml ; \
+    fi
+
 USER nexus


### PR DESCRIPTION
There is Composer support in the Community Edition since 3.77.0 and having both plugins enabled there are conflicts during startup, because both share the same content type "composer".

Add a build step to remove the official Composer plugin from the feature set and only use the community plugin.

Also synchronize the build JDK with our CI pipeline and use Java 17.

----

Without this workaround, running a 3.77 container with our plugin enabled crashes

```
ACTIVATING com.sonatype.nexus.plugins.nexus-repository-composer [3.77.0.08]
ACTIVATED com.sonatype.nexus.plugins.nexus-repository-composer [3.77.0.08]
...
ACTIVATING org.sonatype.nexus.plugins.nexus-repository-composer [0.1.9]
ACTIVATED org.sonatype.nexus.plugins.nexus-repository-composer [0.1.9]
...
Creating schema for ComposerAssetBlobDAO           # <-- from official plugin
Creating schema for ComposerContentRepositoryDAO
Creating schema for ComposerComponentDAO
Creating schema for ComposerAssetDAO
Creating schema for ComposerComponentDAO
Creating schema for ComposerContentRepositoryDAO
Creating schema for ComposerBrowseNodeDAO
Creating schema for DownloadCountDAO
Creating schema for Log4JVisualizerConfigurationDAO
Creating schema for RepositoryMetricsDAO
Creating schema for ComposerBrowseNodeDAO          # <-- from community plugin
Creating schema for ComposerAssetBlobDAO
Creating schema for ComposerAssetDAO

...

Failed to get state from com.google.inject.internal.InjectorImpl$1 (ignored)
java.lang.IllegalStateException: nx-repository-view-composer-*-delete already exists
```
